### PR TITLE
Use --schema-only when calling pg_dump

### DIFF
--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -114,8 +114,12 @@ func (d *PostgresDatabase) Close() error {
 
 func runPgDump(config adapter.Config, table string) (string, error) {
 	cmd := exec.Command(
-		"pg_dump", config.DbName, "-t", table,
-		"-U", config.User, "-h", config.Host, "-p", fmt.Sprintf("%d", config.Port),
+		"pg_dump", config.DbName,
+		"--schema-only",
+		"-t", table,
+		"-U", config.User,
+		"-h", config.Host,
+		"-p", fmt.Sprintf("%d", config.Port),
 	)
 	if len(config.Password) > 0 {
 		cmd.Env = os.Environ()


### PR DESCRIPTION
`pg_dump` will dump the entire contents of a database table without the `--schema-only` option. In `DumpTableDDL()` `COPY` statements are ignored, so there should be no side effect to not generating them in the first place.

The `COPY` command that `pg_dump` generates to dump the table's content doesn't work on Redshift databases, so this PR is also a step towards letting sqldef work on Redshift databases.