### PR TITLE
Remove REVOKE and GRANT statements from dumped SQL

### DIFF
--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -87,6 +87,14 @@ func (d *PostgresDatabase) DumpTableDDL(table string) (string, error) {
 	re = regexp.MustCompilePOSIX("^ALTER TABLE [^ ;]+ OWNER TO .+;$")
 	ddl = re.ReplaceAllLiteralString(ddl, "")
 
+	// Ignore REVOKE statements
+	re = regexp.MustCompilePOSIX("^REVOKE .*;$")
+	ddl = re.ReplaceAllLiteralString(ddl, "")
+
+	// Ignore GRANT statements
+	re = regexp.MustCompilePOSIX("^GRANT .*;$")
+	ddl = re.ReplaceAllLiteralString(ddl, "")
+
 	// Remove empty lines
 	// TODO: there should be a better way....
 	for strings.Replace(ddl, "\n\n", "\n", -1) != ddl {


### PR DESCRIPTION
`GRANT` and `REVOKE` sql statements produced by pg_dump were not being correctly parsed.

I don't think sqldef is intended to manage permissions so rather than attempt to alter the parser to correctly parse them I have added them to the list of statements that are removed from the pg_dump output.

The error I was getting before this change was `syntax error at position 7 near 'revoke'`.