### PR TITLE
Add AFTER and FIRST

### DIFF
--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -107,7 +107,7 @@ func TestMysqldefAddColumn(t *testing.T) {
 		  created_at datetime NOT NULL
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN created_at datetime NOT NULL;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN created_at datetime NOT NULL AFTER name;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`
@@ -117,6 +117,30 @@ func TestMysqldefAddColumn(t *testing.T) {
 		);`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users DROP COLUMN name;\n")
+	assertApplyOutput(t, createTable, nothingModified)
+}
+
+func TestMysqldefAddColumnAfter(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := stripHeredoc(`
+		CREATE TABLE users (
+		  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		  created_at datetime NOT NULL
+		);
+		`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+createTable)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+		  name varchar(40) NOT NULL,
+		  created_at datetime NOT NULL
+		);`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN name varchar(40) NOT NULL AFTER id;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -344,7 +368,7 @@ func TestMysqldefDefaultNull(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN name varchar(40) DEFAULT null;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN name varchar(40) DEFAULT null AFTER id;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -160,7 +160,7 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 	ddls := []string{}
 
 	// Examine each column
-	for _, desiredColumn := range desired.table.columns {
+	for i, desiredColumn := range desired.table.columns {
 		currentColumn := findColumnByName(currentTable.columns, desiredColumn.name)
 		if currentColumn == nil {
 			definition, err := g.generateColumnDefinition(desiredColumn) // TODO: Parse DEFAULT NULL and share this with else
@@ -170,6 +170,15 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 
 			// Column not found, add column.
 			ddl := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", desired.table.name, definition) // TODO: escape
+
+			if g.mode == GeneratorModeMysql {
+				after := " FIRST"
+				if i > 0 {
+					after = " AFTER " + desired.table.columns[i-1].name
+				}
+				ddl += after
+			}
+
 			ddls = append(ddls, ddl)
 		} else {
 			// Column is found, change primary key first as needed.


### PR DESCRIPTION
I have added AFTER and FIRST to 'ALTER TABLE ... ADD COLUMN'.
It can make the sequence of columns same with its CREATE statement.