### PR TITLE
password from prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Application Options:
   -h, --host=host_name       Host to connect to the MySQL server (default: 127.0.0.1)
   -P, --port=port_num        Port used for the connection (default: 3306)
   -S, --socket=socket        The socket file to use for connection
+      --password-prompt      Force MySQL user password prompt
       --file=sql_file        Read schema SQL from the file, rather than stdin (default: -)
       --dry-run              Don't run DDLs but just show them
       --export               Just dump the current schema to stdout
@@ -110,6 +111,7 @@ Application Options:
   -W, --password=password    PostgreSQL user password, overridden by $PGPASS
   -h, --host=hostname        Host or socket directory to connect to the PostgreSQL server (default: 127.0.0.1)
   -p, --port=port            Port used for the connection (default: 5432)
+      --password-prompt      Force PostgreSQL user password prompt
   -f, --file=filename        Read schema SQL from the file, rather than stdin (default: -)
       --dry-run              Don't run DDLs but just show them
       --export               Just dump the current schema to stdout

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/howeyc/gopass"
 	"github.com/jessevdk/go-flags"
 	"github.com/k0kubun/sqldef"
 	"github.com/k0kubun/sqldef/adapter"
@@ -21,6 +22,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		Host     string `short:"h" long:"host" description:"Host to connect to the MySQL server" value-name:"host_name" default:"127.0.0.1"`
 		Port     uint   `short:"P" long:"port" description:"Port used for the connection" value-name:"port_num" default:"3306"`
 		Socket   string `short:"S" long:"socket" description:"The socket file to use for connection" value-name:"socket"`
+		Prompt   bool   `long:"password-prompt" description:"Force MySQL user password prompt"`
 		File     string `long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
 		DryRun   bool   `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export   bool   `long:"export" description:"Just dump the current schema to stdout"`
@@ -59,6 +61,15 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	password, ok := os.LookupEnv("MYSQL_PWD")
 	if !ok {
 		password = opts.Password
+	}
+
+	if opts.Prompt {
+		fmt.Printf("Enter Password: ")
+		pass, err := gopass.GetPasswd()
+		if err != nil {
+			log.Fatal(err)
+		}
+		password = string(pass)
 	}
 
 	config := adapter.Config{

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/howeyc/gopass"
 	"github.com/jessevdk/go-flags"
 	"github.com/k0kubun/sqldef"
 	"github.com/k0kubun/sqldef/adapter"
@@ -20,6 +21,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		Password string `short:"W" long:"password" description:"PostgreSQL user password, overridden by $PGPASS" value-name:"password"`
 		Host     string `short:"h" long:"host" description:"Host or socket directory to connect to the PostgreSQL server" value-name:"hostname" default:"127.0.0.1"`
 		Port     uint   `short:"p" long:"port" description:"Port used for the connection" value-name:"port" default:"5432"`
+		Prompt   bool   `long:"password-prompt" description:"Force PostgreSQL user password prompt"`
 		File     string `short:"f" long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"filename" default:"-"`
 		DryRun   bool   `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export   bool   `long:"export" description:"Just dump the current schema to stdout"`
@@ -58,6 +60,15 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	password, ok := os.LookupEnv("PGPASS")
 	if !ok {
 		password = opts.Password
+	}
+
+	if opts.Prompt {
+		fmt.Printf("Enter Password: ")
+		pass, err := gopass.GetPasswd()
+		if err != nil {
+			log.Fatal(err)
+		}
+		password = string(pass)
 	}
 
 	config := adapter.Config{


### PR DESCRIPTION
I do not want to record password in history or environment.
I implemented using prompt. 

Add `--password-prompt` option to mysqldef and psqldef command

I understand native option of mysql or pg_dump, psql command.
But go-flags does not allow empty value. ( Is wrong? )