### PR TITLE
MySQL timestamp initialization "ON UPDATE CURRENT_TIMESTAMP"

### DIFF
--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -480,6 +480,43 @@ func TestMysqldefDefaultNull(t *testing.T) {
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
+func TestMysqldefOnUpdate(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := stripHeredoc(`
+		CREATE TABLE users (
+		  name varchar(40),
+		  updated_at datetime DEFAULT current_timestamp ON UPDATE current_timestamp,
+		  created_at datetime NOT NULL
+		);
+		`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+createTable)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  name varchar(40),
+		  updated_at datetime DEFAULT current_timestamp,
+		  created_at datetime NOT NULL
+		);
+		`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users CHANGE COLUMN updated_at updated_at datetime DEFAULT current_timestamp;\n")
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  name varchar(40),
+		  updated_at datetime DEFAULT current_timestamp ON UPDATE current_timestamp,
+		  created_at datetime NOT NULL
+		);
+		`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users CHANGE COLUMN updated_at updated_at datetime DEFAULT current_timestamp ON UPDATE current_timestamp;\n")
+	assertApplyOutput(t, createTable, nothingModified)
+}
+
 func TestMysqldefIgnoreView(t *testing.T) {
 	resetTestDatabase()
 

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -51,6 +51,7 @@ type Column struct {
 	length        *Value
 	scale         *Value
 	keyOption     ColumnKeyOption
+	onUpdate      *Value
 	// TODO: keyopt
 	// XXX: charset, collate, zerofill?
 }

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -4,6 +4,7 @@ package schema
 import (
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 )
 
@@ -402,6 +403,10 @@ func (g *Generator) generateColumnDefinition(column Column) (string, error) {
 		definition += "AUTO_INCREMENT "
 	}
 
+	if column.onUpdate != nil {
+		definition += fmt.Sprintf("ON UPDATE %s ", string(column.onUpdate.raw))
+	}
+
 	switch column.keyOption {
 	case ColumnKeyNone:
 		// noop
@@ -597,7 +602,8 @@ func haveSameDataType(current Column, desired Column) bool {
 	return (normalizeDataType(current.typeName) == normalizeDataType(desired.typeName)) &&
 		(current.unsigned == desired.unsigned) &&
 		(current.notNull == (desired.notNull || desired.keyOption == ColumnKeyPrimary)) && // `PRIMARY KEY` implies `NOT NULL`
-		(current.autoIncrement == desired.autoIncrement)
+		(current.autoIncrement == desired.autoIncrement) &&
+		reflect.DeepEqual(current.onUpdate, desired.onUpdate)
 
 	// TODO: check defaultVal, length, scale
 

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -81,6 +81,7 @@ func parseTable(stmt *sqlparser.DDL) Table {
 			length:        parseValue(parsedCol.Type.Length),
 			scale:         parseValue(parsedCol.Type.Scale),
 			keyOption:     ColumnKeyOption(parsedCol.Type.KeyOpt), // FIXME: tight coupling in enum order
+			onUpdate:      parseValue(parsedCol.Type.OnUpdate),
 		}
 		columns = append(columns, column)
 	}


### PR DESCRIPTION
MySQL "ON UPDATE CURRENT_TIMESTAMP"  support.

"ON UPDATE" is already parsed. 
https://github.com/k0kubun/sqldef/blob/6ae81394adbb0b2d854237e7a9e2db0f08835fac/sqlparser/parser.y#L720

I know that "defaultVal, length, scale" vales are difficult to compare.
But  "ON UPDATE" value is easy to compare.

