### PR TITLE
Fix to preserve line feeds when using stdin

### DIFF
--- a/sqldef.go
+++ b/sqldef.go
@@ -60,27 +60,24 @@ func Run(generatorMode schema.GeneratorMode, db adapter.Database, options *Optio
 }
 
 func readFile(filepath string) (string, error) {
-	var content string
 	var err error
+	var buf []byte
+
 	if filepath == "-" {
 		stat, _ := os.Stdin.Stat()
 		if (stat.Mode() & os.ModeCharDevice) != 0 {
 			return "", fmt.Errorf("stdin is not piped")
 		}
 
-		var buf []byte
 		buf, err = ioutil.ReadAll(os.Stdin)
-		content = string(buf)
 	} else {
-		var buf []byte
 		buf, err = ioutil.ReadFile(filepath)
-		content = string(buf)
 	}
 
 	if err != nil {
 		return "", err
 	}
-	return content, nil
+	return string(buf), nil
 }
 
 func showDDLs(ddls []string) {

--- a/sqldef.go
+++ b/sqldef.go
@@ -1,8 +1,6 @@
 package sqldef
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -70,12 +68,9 @@ func readFile(filepath string) (string, error) {
 			return "", fmt.Errorf("stdin is not piped")
 		}
 
-		var buffer bytes.Buffer
-		scanner := bufio.NewScanner(os.Stdin)
-		for scanner.Scan() {
-			buffer.WriteString(scanner.Text())
-		}
-		content = buffer.String()
+		var buf []byte
+		buf, err = ioutil.ReadAll(os.Stdin)
+		content = string(buf)
 	} else {
 		var buf []byte
 		buf, err = ioutil.ReadFile(filepath)


### PR DESCRIPTION
Currently `sqldef.readFile` function removes line ending characters when input from stdin.
DDL is almost valid even if their lines are combined, but line-sensitive syntax (e.g. `-- line comments`) is broken.

Here is an example schema, including simple table definition written in multiline.

```
CREATE TABLE `sample` (
  `id` INT -- ID
);
```

`--file` option works well because it preserves line endings.

```
% mysqldef -uroot example --dry-run --file sample.sql 
-- dry run --
CREATE TABLE `sample` (
  `id` INT -- ID
);
```

However stdin is not working.

```
% mysqldef -uroot example --dry-run < sample.sql
found syntax error when parsing DDL "CREATE TABLE `sample` (  `id` INT -- ID)": syntax error at position 41
```

Given lines are combined, and `-- ID` is no longer valid line comment.

I tested this with mac and mysql, but other platform or other db adapters are considered to have same issue.