### PR TITLE
Make error outputs more detail to show pg_dump errors

### DIFF
--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -140,7 +140,7 @@ func runPgDump(config adapter.Config, table string) (string, error) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("%s :\n\n  %s\n", err, out)
+		return "", fmt.Errorf("%s :\n%s\n", err, out)
 	}
 
 	return string(out), nil

--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -138,9 +138,9 @@ func runPgDump(config adapter.Config, table string) (string, error) {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("PGPASSWORD=%s", config.Password)) // XXX: Can we pass this in DSN format in a safe way?
 	}
 
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%s :\n\n  %s\n", err, out)
 	}
 
 	return string(out), nil


### PR DESCRIPTION
#29 

before
```
2019/08/14 17:28:33 Error on DumpDDLs: exit status 1
```

after
```
2019/08/14 17:28:33 Error on DumpDDLs: exit status 1 :
  pg_dump: server version: 10.1; pg_dump version: 9.6.15
pg_dump: aborting because of server version mismatch
```