### PR TITLE
Support timestamp (without tz) on psqldef

### DIFF
--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -115,17 +115,31 @@ type column struct {
 }
 
 func (c *column) GetDataType() string {
-	if c.IsAutoIncrement {
-		switch c.dataType {
-		case "smallint":
+	switch c.dataType {
+	case "smallint":
+		if c.IsAutoIncrement {
 			return "smallserial"
-		case "integer":
+		}
+		return c.dataType
+	case "integer":
+		if c.IsAutoIncrement {
 			return "serial"
-		case "bigint":
+		}
+		return c.dataType
+	case "bigint":
+		if c.IsAutoIncrement {
 			return "bigserial"
 		}
+		return c.dataType
+	case "timestamp without time zone":
+		// Note:
+		// The SQL standard requires that writing just timestamp be equivalent to timestamp without time zone, and PostgreSQL honors that behavior.
+		// timestamptz is accepted as an abbreviation for timestamp with time zone; this is a PostgreSQL extension.
+		// https://www.postgresql.org/docs/9.6/datatype-datetime.html
+		return "timestamp"
+	default:
+		return c.dataType
 	}
-	return c.dataType
 }
 
 func (d *PostgresDatabase) getColumns(table string) ([]column, error) {

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -263,6 +263,7 @@ func TestPsqldefDataTypes(t *testing.T) {
 		  c_character_20 character(20),
 		  c_character_varying_30 character varying(30),
 		  c_date date,
+		  c_timestamp_without_tz timestamp,
 		  c_int int,
 		  c_integer integer,
 		  c_serial serial,


### PR DESCRIPTION
In the current implementation not support this schema

```sql
CREATE TABLE users (
  id bigint NOT NULL,
  name text,
  created_at timestamp
);
```

This PR is supported `timestamp` only.
Not support `timestamp without tz` and `timestamp with tz`