### PR TITLE
Fix output length when `psqldef --export`

### DIFF
--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -75,6 +75,9 @@ func buildDumpTableDDL(table string, columns []column, primaryKeyDef string, ind
 		isLast := i == len(columns)-1
 		fmt.Fprint(&queryBuilder, indent)
 		fmt.Fprintf(&queryBuilder, "%s %s", col.Name, col.GetDataType())
+		if col.Length > 0 {
+			fmt.Fprintf(&queryBuilder, "(%d)", col.Length)
+		}
 		if col.IsUnique {
 			fmt.Fprint(&queryBuilder, " UNIQUE")
 		}

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -302,17 +302,25 @@ func TestPsqldefExport(t *testing.T) {
 	assertEquals(t, out, "-- No table exists --\n")
 
 	mustExecute("psql", "-Upostgres", "psqldef_test", "-c", stripHeredoc(`
-	    CREATE TABLE users (
-	        id bigint NOT NULL PRIMARY KEY,
-	        age int
-	    );`,
+		CREATE TABLE users (
+		    id bigint NOT NULL PRIMARY KEY,
+		    age int,
+		    c_char_1 char,
+		    c_char_10 char(10),
+		    c_varchar_10 varchar(10),
+		    c_varchar_unlimited varchar
+		);`,
 	))
 	out = assertedExecute(t, "psqldef", "-Upostgres", "psqldef_test", "--export")
 	// workaround: local has `public.` but travis doesn't.
 	assertEquals(t, strings.Replace(out, "public.users", "users", 2), stripHeredoc(`
 		CREATE TABLE users (
 		    id bigint NOT NULL,
-		    age integer
+		    age integer,
+		    c_char_1 character(1),
+		    c_char_10 character(10),
+		    c_varchar_10 character varying(10),
+		    c_varchar_unlimited character varying
 		);
 		ALTER TABLE ONLY users
 		    ADD CONSTRAINT users_pkey PRIMARY KEY (id);


### PR DESCRIPTION
If applied, this commit will fix #35