### PR TITLE
Fix segmentation violation

### DIFF
--- a/schema/generator.go
+++ b/schema/generator.go
@@ -723,11 +723,23 @@ func (g *Generator) haveSameColumnDefinition(current Column, desired Column) boo
 	// Not examining AUTO_INCREMENT and UNIQUE KEY because it'll be added in a later stage
 	return g.haveSameDataType(current, desired) &&
 		(current.unsigned == desired.unsigned) &&
-		((current.notNull != nil && *current.notNull) == ((desired.notNull != nil && *current.notNull) || desired.keyOption == ColumnKeyPrimary)) && // `PRIMARY KEY` implies `NOT NULL`
+		(isAcceptableNull(current) == isAcceptableNull(desired)) &&
 		(current.timezone == desired.timezone) &&
 		(desired.charset == "" || current.charset == desired.charset) && // detect change column only when set explicitly. TODO: can we calculate implicit charset?
 		(desired.collate == "" || current.collate == desired.collate) && // detect change column only when set explicitly. TODO: can we calculate implicit collate?
 		reflect.DeepEqual(current.onUpdate, desired.onUpdate)
+}
+
+func isAcceptableNull(c Column) bool {
+	// `PRIMARY KEY` implies `NOT NULL`
+	if c.keyOption == ColumnKeyPrimary {
+		return true
+	}
+
+	if c.notNull == nil {
+		return false
+	}
+	return *c.notNull
 }
 
 func (g *Generator) haveSameDataType(current Column, desired Column) bool {


### PR DESCRIPTION
## Problem

sqldef fails on change column definitions from implicit NULL to NOT NULL.

sqldef version: v0.7.6

## Expected

```sql
ALTER TABLE sample CHANGE COLUMN name name varchar(255) NOT NULL
```

### Initial schema

```sql
CREATE TABLE sample (
    name varchar(255) DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
```

### Input DDLs

```sql
CREATE TABLE sample (
    name varchar(255) NOT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
```

### Output DDLs

```
$ cat test.sql 
CREATE TABLE sample (
  name varchar(255) NOT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

$ mysqldef -uroot dev < test.sql 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x5b14a9]

goroutine 1 [running]:
github.com/k0kubun/sqldef/schema.(*Generator).haveSameColumnDefinition(0xc000159cc0, 0xc00011e21c, 0x4, 0x0, 0xc00011e207, 0x7, 0x0, 0x0, 0x0, 0xc00011c140, ...)
        /mnt/c/Users/kyohe/wsl2/ubuntu/dev/github.com/k0kubun/sqldef/schema/generator.go:726 +0xe9
github.com/k0kubun/sqldef/schema.(*Generator).generateDDLsForCreateTable(0xc000159cc0, 0xc00011e1d0, 0x6, 0xc00013c420, 0x1, 0x1, 0xaa7270, 0x0, 0x0, 0xaa7270, ...)
        /mnt/c/Users/kyohe/wsl2/ubuntu/dev/github.com/k0kubun/sqldef/schema/generator.go:203 +0x276b
github.com/k0kubun/sqldef/schema.(*Generator).generateDDLs(0xc000159cc0, 0xc000120080, 0x1, 0x1, 0x1, 0x1, 0x0, 0x0, 0xc00012e000)
        /mnt/c/Users/kyohe/wsl2/ubuntu/dev/github.com/k0kubun/sqldef/schema/generator.go:74 +0x1a90
github.com/k0kubun/sqldef/schema.GenerateIdempotentDDLs(0x0, 0xc00012e000, 0x5c, 0xc000126000, 0x7d, 0x0, 0x83f820, 0xaa7270, 0xc00005ad78, 0x40e0a8)
        /mnt/c/Users/kyohe/wsl2/ubuntu/dev/github.com/k0kubun/sqldef/schema/generator.go:61 +0x1bb
github.com/k0kubun/sqldef.Run(0x0, 0x846240, 0xc0000b21e0, 0xc0000a42c0)
        /mnt/c/Users/kyohe/wsl2/ubuntu/dev/github.com/k0kubun/sqldef/sqldef.go:43 +0x297
main.main()
        /mnt/c/Users/kyohe/wsl2/ubuntu/dev/github.com/k0kubun/sqldef/cmd/mysqldef/mysqldef.go:97 +0x1c6
```
