### PR TITLE
Add `t.Helper()`

### DIFF
--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -1261,17 +1261,20 @@ func TestMain(m *testing.M) {
 }
 
 func assertApply(t *testing.T, schema string) {
+	t.Helper()
 	writeFile("schema.sql", schema)
 	assertedExecute(t, "mysqldef", "-uroot", "mysqldef_test", "--file", "schema.sql")
 }
 
 func assertApplyOutput(t *testing.T, schema string, expected string) {
+	t.Helper()
 	writeFile("schema.sql", schema)
 	actual := assertedExecute(t, "mysqldef", "-uroot", "mysqldef_test", "--file", "schema.sql")
 	assertEquals(t, actual, expected)
 }
 
 func assertApplyFailure(t *testing.T, schema string, expected string) {
+	t.Helper()
 	writeFile("schema.sql", schema)
 	actual, err := execute("mysqldef", "-uroot", "mysqldef_test", "--file", "schema.sql")
 	if err == nil {
@@ -1290,6 +1293,7 @@ func mustExecute(command string, args ...string) string {
 }
 
 func assertedExecute(t *testing.T, command string, args ...string) string {
+	t.Helper()
 	out, err := execute(command, args...)
 	if err != nil {
 		t.Errorf("failed to execute '%s %s' (error: '%s'): `%s`", command, strings.Join(args, " "), err, out)
@@ -1298,6 +1302,7 @@ func assertedExecute(t *testing.T, command string, args ...string) string {
 }
 
 func assertEquals(t *testing.T, actual string, expected string) {
+	t.Helper()
 	if expected != actual {
 		t.Errorf("expected `%s` but got `%s`", expected, actual)
 	}

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -591,11 +591,13 @@ func TestMain(m *testing.M) {
 }
 
 func assertApply(t *testing.T, schema string) {
+	t.Helper()
 	writeFile("schema.sql", schema)
 	assertedExecute(t, "psqldef", "-Upostgres", "psqldef_test", "--file", "schema.sql")
 }
 
 func assertApplyOutput(t *testing.T, schema string, expected string) {
+	t.Helper()
 	writeFile("schema.sql", schema)
 	actual := assertedExecute(t, "psqldef", "-Upostgres", "psqldef_test", "--file", "schema.sql")
 	assertEquals(t, actual, expected)
@@ -610,6 +612,7 @@ func mustExecute(command string, args ...string) {
 }
 
 func assertedExecute(t *testing.T, command string, args ...string) string {
+	t.Helper()
 	out, err := execute(command, args...)
 	if err != nil {
 		t.Errorf("failed to execute '%s %s' (error: '%s'): `%s`", command, strings.Join(args, " "), err, out)
@@ -618,6 +621,7 @@ func assertedExecute(t *testing.T, command string, args ...string) string {
 }
 
 func assertEquals(t *testing.T, actual string, expected string) {
+	t.Helper()
 	if expected != actual {
 		t.Errorf("expected '%s' but got '%s'", expected, actual)
 	}

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -188,11 +188,13 @@ func TestMain(m *testing.M) {
 }
 
 func assertApply(t *testing.T, schema string) {
+	t.Helper()
 	writeFile("schema.sql", schema)
 	assertedExecute(t, "sqlite3def", "sqlite3def_test", "--file", "schema.sql")
 }
 
 func assertApplyOutput(t *testing.T, schema string, expected string) {
+	t.Helper()
 	writeFile("schema.sql", schema)
 	actual := assertedExecute(t, "sqlite3def", "sqlite3def_test", "--file", "schema.sql")
 	assertEquals(t, actual, expected)
@@ -207,6 +209,7 @@ func mustExecute(command string, args ...string) {
 }
 
 func assertedExecute(t *testing.T, command string, args ...string) string {
+	t.Helper()
 	out, err := execute(command, args...)
 	if err != nil {
 		t.Errorf("failed to execute '%s %s' (error: '%s'): `%s`", command, strings.Join(args, " "), err, out)
@@ -215,6 +218,7 @@ func assertedExecute(t *testing.T, command string, args ...string) string {
 }
 
 func assertEquals(t *testing.T, actual string, expected string) {
+	t.Helper()
 	if expected != actual {
 		t.Errorf("expected '%s' but got '%s'", expected, actual)
 	}

--- a/sqlparser/dependency/hack/hack_test.go
+++ b/sqlparser/dependency/hack/hack_test.go
@@ -62,12 +62,14 @@ func TestStringArena(t *testing.T) {
 }
 
 func checkstring(t *testing.T, actual, expected string) {
+	t.Helper()
 	if actual != expected {
 		t.Errorf("received %s, expecting %s", actual, expected)
 	}
 }
 
 func checkint(t *testing.T, actual, expected int) {
+	t.Helper()
 	if actual != expected {
 		t.Errorf("received %d, expecting %d", actual, expected)
 	}


### PR DESCRIPTION
When the test is in error, the number of lines of the test helper is output as shown below.

```
sqlite3def_test.go:212: failed to execute 'sqlite3def sqlite3def_test --file schema.sql' (error: 'exit status 1'): `found syntax error when parsing DDL "CREATE VIEW `view_users` AS select id from users where age = 1": syntax error at position 14 near '`'
```

This makes it difficult to investigate errors, so use `t.Helper()` to display the number of lines called.
https://golang.org/pkg/testing/#T.Helper