### PR TITLE
Add identifier escaping process

### DIFF
--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -487,7 +487,7 @@ func TestMysqldefSwapColumn(t *testing.T) {
 	)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE `users` CHANGE COLUMN `nickname` `nickname` varchar(20) NOT NULL AFTER id;\n",
+		"ALTER TABLE `users` CHANGE COLUMN `nickname` `nickname` varchar(20) NOT NULL AFTER `id`;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -77,7 +77,7 @@ func TestMysqldefCreateTableDropPrimaryKey(t *testing.T) {
 		  name varchar(20)
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users DROP PRIMARY KEY;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` DROP PRIMARY KEY;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`
@@ -87,8 +87,8 @@ func TestMysqldefCreateTableDropPrimaryKey(t *testing.T) {
 		);`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users CHANGE COLUMN name name varchar(20) NOT NULL;\n"+
-		"ALTER TABLE users ADD primary key (`name`);\n",
+		"ALTER TABLE `users` CHANGE COLUMN `name` `name` varchar(20) NOT NULL;\n"+
+		"ALTER TABLE `users` ADD primary key (`name`);\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -116,7 +116,7 @@ func TestMysqldefCreateTableAddPrimaryKey(t *testing.T) {
 	)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users ADD primary key (`id`);\n",
+		"ALTER TABLE `users` ADD primary key (`id`);\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -146,8 +146,8 @@ func TestMysqldefCreateTableChangePrimaryKey(t *testing.T) {
 	)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE friends DROP PRIMARY KEY;\n"+
-		"ALTER TABLE friends ADD primary key (`user_id`, `friend_id`);\n",
+		"ALTER TABLE `friends` DROP PRIMARY KEY;\n"+
+		"ALTER TABLE `friends` ADD primary key (`user_id`, `friend_id`);\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -174,9 +174,9 @@ func TestMysqldefCreateTableAddAutoIncrementPrimaryKey(t *testing.T) {
 	)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users ADD COLUMN id bigint NOT NULL FIRST;\n"+
-		"ALTER TABLE users ADD primary key (`id`);\n"+
-		"ALTER TABLE users CHANGE COLUMN id id bigint NOT NULL AUTO_INCREMENT;\n",
+		"ALTER TABLE `users` ADD COLUMN `id` bigint NOT NULL FIRST;\n"+
+		"ALTER TABLE `users` ADD primary key (`id`);\n"+
+		"ALTER TABLE `users` CHANGE COLUMN `id` `id` bigint NOT NULL AUTO_INCREMENT;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -204,7 +204,7 @@ func TestMysqldefCreateTableKeepAutoIncrement(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users CHANGE COLUMN id id bigint NOT NULL AUTO_INCREMENT;\n",
+		"ALTER TABLE `users` CHANGE COLUMN `id` `id` bigint NOT NULL AUTO_INCREMENT;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -231,7 +231,7 @@ func TestMysqldefCreateTableChangeAutoIncrement(t *testing.T) {
 	)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users CHANGE COLUMN id id bigint(20) NOT NULL AUTO_INCREMENT;\n",
+		"ALTER TABLE `users` CHANGE COLUMN `id` `id` bigint(20) NOT NULL AUTO_INCREMENT;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 
@@ -243,7 +243,7 @@ func TestMysqldefCreateTableChangeAutoIncrement(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users CHANGE COLUMN id id bigint(20) NOT NULL;\n",
+		"ALTER TABLE `users` CHANGE COLUMN `id` `id` bigint(20) NOT NULL;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -269,9 +269,9 @@ func TestMysqldefCreateTableRemoveAutoIncrementPrimaryKey(t *testing.T) {
 	)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE friends CHANGE COLUMN id id bigint(20) NOT NULL;\n"+
-		"ALTER TABLE friends DROP PRIMARY KEY;\n"+
-		"ALTER TABLE friends DROP COLUMN id;\n",
+		"ALTER TABLE `friends` CHANGE COLUMN `id` `id` bigint(20) NOT NULL;\n"+
+		"ALTER TABLE `friends` DROP PRIMARY KEY;\n"+
+		"ALTER TABLE `friends` DROP COLUMN `id`;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -296,7 +296,7 @@ func TestMysqldefAddColumn(t *testing.T) {
 		  created_at datetime NOT NULL
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN created_at datetime NOT NULL AFTER name;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `created_at` datetime NOT NULL AFTER `name`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`
@@ -305,7 +305,7 @@ func TestMysqldefAddColumn(t *testing.T) {
 		  created_at datetime NOT NULL
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users DROP COLUMN name;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` DROP COLUMN `name`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -329,7 +329,7 @@ func TestMysqldefAddColumnAfter(t *testing.T) {
 		  created_at datetime NOT NULL
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN name varchar(40) NOT NULL AFTER id;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `name` varchar(40) NOT NULL AFTER `id`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -353,7 +353,7 @@ func TestMysqldefAddColumnWithNull(t *testing.T) {
 		  created_at timestamp NULL DEFAULT NULL
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN created_at timestamp NULL DEFAULT null AFTER name;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `created_at` timestamp NULL DEFAULT null AFTER `name`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -378,8 +378,8 @@ func TestMysqldefChangeColumn(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+stripHeredoc(`
-		ALTER TABLE users CHANGE COLUMN id id bigint UNSIGNED NOT NULL;
-		ALTER TABLE users CHANGE COLUMN name name char(40);
+		ALTER TABLE `+"`users`"+` CHANGE COLUMN `+"`id` `id`"+` bigint UNSIGNED NOT NULL;
+		ALTER TABLE `+"`users`"+` CHANGE COLUMN `+"`name` `name`"+` char(40);
 		`,
 	))
 	assertApplyOutput(t, createTable, nothingModified)
@@ -406,7 +406,7 @@ func TestMysqldefChangeColumnLength(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+stripHeredoc(`
-		ALTER TABLE users CHANGE COLUMN name name varchar(1000) COLLATE utf8mb4_bin DEFAULT null;
+		ALTER TABLE `+"`users`"+` CHANGE COLUMN `+"`name` `name`"+` varchar(1000) COLLATE utf8mb4_bin DEFAULT null;
 		`,
 	))
 	assertApplyOutput(t, createTable, nothingModified)
@@ -431,7 +431,7 @@ func TestMysqldefChangeColumnBinary(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users CHANGE COLUMN word word varchar(64) COLLATE utf8mb4_bin NOT NULL;\n",
+		"ALTER TABLE `users` CHANGE COLUMN `word` `word` varchar(64) COLLATE utf8mb4_bin NOT NULL;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -455,7 +455,7 @@ func TestMysqldefChangeColumnCollate(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users CHANGE COLUMN password password char(128) CHARACTER SET latin1 COLLATE latin1_bin;\n",
+		"ALTER TABLE `users` CHANGE COLUMN `password` `password` char(128) CHARACTER SET latin1 COLLATE latin1_bin;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -487,7 +487,7 @@ func TestMysqldefSwapColumn(t *testing.T) {
 	)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users CHANGE COLUMN nickname nickname varchar(20) NOT NULL AFTER id;\n",
+		"ALTER TABLE `users` CHANGE COLUMN `nickname` `nickname` varchar(20) NOT NULL AFTER id;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -504,15 +504,15 @@ func TestMysqldefAddIndex(t *testing.T) {
 	)
 	assertApply(t, createTable)
 
-	alterTable := "ALTER TABLE users ADD UNIQUE INDEX `index_name`(name);\n"
+	alterTable := "ALTER TABLE `users` ADD UNIQUE INDEX `index_name`(`name`);\n"
 	assertApplyOutput(t, createTable+alterTable, applyPrefix+alterTable)
 	assertApplyOutput(t, createTable+alterTable, nothingModified)
 
-	alterTable = "ALTER TABLE users ADD INDEX `index_name`(name, created_at);\n"
-	assertApplyOutput(t, createTable+alterTable, applyPrefix+"ALTER TABLE users DROP INDEX `index_name`;\n"+alterTable)
+	alterTable = "ALTER TABLE `users` ADD INDEX `index_name`(`name`, `created_at`);\n"
+	assertApplyOutput(t, createTable+alterTable, applyPrefix+"ALTER TABLE `users` DROP INDEX `index_name`;\n"+alterTable)
 	assertApplyOutput(t, createTable+alterTable, nothingModified)
 
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users DROP INDEX `index_name`;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` DROP INDEX `index_name`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -536,7 +536,7 @@ func TestMysqldefFulltextIndex(t *testing.T) {
 		  title varchar(40) DEFAULT NULL
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE posts DROP INDEX `title_fulltext_index`;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `posts` DROP INDEX `title_fulltext_index`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`
@@ -546,7 +546,7 @@ func TestMysqldefFulltextIndex(t *testing.T) {
 		  FULLTEXT KEY title_fulltext_index (title) /*!50100 WITH PARSER ngram */
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE posts ADD fulltext key `title_fulltext_index`(`title`);\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `posts` ADD fulltext key `title_fulltext_index`(`title`);\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -568,8 +568,8 @@ func TestMysqldefCreateIndex(t *testing.T) {
 	assertApplyOutput(t, createTable+createIndex1+createIndex2, nothingModified)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users DROP INDEX `index_created_at`;\n"+
-		"ALTER TABLE users DROP INDEX `index_name`;\n",
+		"ALTER TABLE `users` DROP INDEX `index_created_at`;\n"+
+		"ALTER TABLE `users` DROP INDEX `index_name`;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -599,8 +599,8 @@ func TestMysqldefCreateTableKey(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users ADD key `index_name`(`name`);\n"+
-		"ALTER TABLE users ADD unique key `index_created_at`(`created_at`);\n",
+		"ALTER TABLE `users` ADD key `index_name`(`name`);\n"+
+		"ALTER TABLE `users` ADD unique key `index_created_at`(`created_at`);\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -625,7 +625,7 @@ func TestMysqldefCreateTableWithUniqueColumn(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users ADD COLUMN name varchar(40) UNIQUE AFTER id;\n",
+		"ALTER TABLE `users` ADD COLUMN `name` varchar(40) UNIQUE AFTER `id`;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 
@@ -636,8 +636,8 @@ func TestMysqldefCreateTableWithUniqueColumn(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users DROP INDEX `name`;\n"+
-		"ALTER TABLE users DROP COLUMN name;\n",
+		"ALTER TABLE `users` DROP INDEX `name`;\n"+
+		"ALTER TABLE `users` DROP COLUMN `name`;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -661,7 +661,7 @@ func TestMysqldefCreateTableChangeUniqueColumn(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users ADD UNIQUE KEY name(name);\n",
+		"ALTER TABLE `users` ADD UNIQUE KEY `name`(`name`);\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 
@@ -672,7 +672,7 @@ func TestMysqldefCreateTableChangeUniqueColumn(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users DROP INDEX `name`;\n",
+		"ALTER TABLE `users` DROP INDEX `name`;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -700,7 +700,7 @@ func TestMysqldefCreateTableForeignKey(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createUsers+createPosts, applyPrefix+"ALTER TABLE posts ADD CONSTRAINT posts_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id);\n")
+	assertApplyOutput(t, createUsers+createPosts, applyPrefix+"ALTER TABLE `posts` ADD CONSTRAINT `posts_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);\n")
 	assertApplyOutput(t, createUsers+createPosts, nothingModified)
 
 	// Add options to a foreign key
@@ -712,7 +712,7 @@ func TestMysqldefCreateTableForeignKey(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createUsers+createPosts, applyPrefix+"ALTER TABLE posts DROP FOREIGN KEY posts_ibfk_1;\nALTER TABLE posts ADD CONSTRAINT posts_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE;\n")
+	assertApplyOutput(t, createUsers+createPosts, applyPrefix+"ALTER TABLE `posts` DROP FOREIGN KEY `posts_ibfk_1`;\nALTER TABLE `posts` ADD CONSTRAINT `posts_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;\n")
 	assertApplyOutput(t, createUsers+createPosts, nothingModified)
 
 	// Drop a foreign key
@@ -724,8 +724,8 @@ func TestMysqldefCreateTableForeignKey(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createUsers+createPosts, applyPrefix+
-		"ALTER TABLE posts DROP FOREIGN KEY posts_ibfk_1;\n"+
-		"ALTER TABLE posts DROP INDEX `posts_ibfk_1`;\n",
+		"ALTER TABLE `posts` DROP FOREIGN KEY `posts_ibfk_1`;\n"+
+		"ALTER TABLE `posts` DROP INDEX `posts_ibfk_1`;\n",
 	)
 	assertApplyOutput(t, createUsers+createPosts, nothingModified)
 
@@ -739,7 +739,7 @@ func TestMysqldefCreateTableForeignKey(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createUsers+createPosts, applyPrefix+
-		"ALTER TABLE posts ADD CONSTRAINT posts_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL ON UPDATE CASCADE;\n")
+		"ALTER TABLE `posts` ADD CONSTRAINT `posts_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;\n")
 	assertApplyOutput(t, createUsers+createPosts, nothingModified)
 }
 
@@ -801,7 +801,7 @@ func TestMysqldefKeywordIndexColumns(t *testing.T) {
 		"  KEY `index_character`(`character`)\n" +
 		");\n"
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE tools ADD key `index_character`(`character`);\n")
+		"ALTER TABLE `tools` ADD key `index_character`(`character`);\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -880,7 +880,7 @@ func TestMysqldefDefaultNull(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN name varchar(40) DEFAULT null AFTER id;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `name` varchar(40) DEFAULT null AFTER `id`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -903,7 +903,7 @@ func TestMysqldefAddNotNull(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users CHANGE COLUMN name name varchar(255) NOT NULL;\n",
+		"ALTER TABLE `users` CHANGE COLUMN `name` `name` varchar(255) NOT NULL;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -930,7 +930,7 @@ func TestMysqldefCreateTableAddColumnWithCharsetAndNotNull(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users ADD COLUMN name varchar(20) CHARACTER SET ascii COLLATE ascii_bin NOT NULL AFTER id;\n",
+		"ALTER TABLE `users` ADD COLUMN `name` varchar(20) CHARACTER SET ascii COLLATE ascii_bin NOT NULL AFTER `id`;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -957,7 +957,7 @@ func TestMysqldefOnUpdate(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users CHANGE COLUMN updated_at updated_at datetime DEFAULT current_timestamp;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` CHANGE COLUMN `updated_at` `updated_at` datetime DEFAULT current_timestamp;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`
@@ -968,7 +968,7 @@ func TestMysqldefOnUpdate(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users CHANGE COLUMN updated_at updated_at datetime DEFAULT current_timestamp ON UPDATE current_timestamp;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` CHANGE COLUMN `updated_at` `updated_at` datetime DEFAULT current_timestamp ON UPDATE current_timestamp;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -991,7 +991,7 @@ func TestMysqldefCurrentTimestampWithPrecision(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN updated_at datetime(6) DEFAULT current_timestamp(6) ON UPDATE current_timestamp(6) AFTER created_at;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `updated_at` datetime(6) DEFAULT current_timestamp(6) ON UPDATE current_timestamp(6) AFTER `created_at`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -1014,7 +1014,7 @@ func TestMysqldefEnumValues(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE users ADD COLUMN authorities enum('normal', 'admin') NOT NULL DEFAULT 'normal' AFTER id;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `authorities` enum('normal', 'admin') NOT NULL DEFAULT 'normal' AFTER `id`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -1047,13 +1047,13 @@ func TestMysqldefView(t *testing.T) {
 		`,
 	)
 	expected := stripHeredoc(`
-		CREATE OR REPLACE VIEW foo AS select u.id as id, p.id as post_id from (mysqldef_test.users as u join mysqldef_test.posts as p on (((u.id = p.user_id) and (p.is_deleted = 0))));
+		CREATE OR REPLACE VIEW ` + "`foo`" + ` AS select u.id as id, p.id as post_id from (mysqldef_test.users as u join mysqldef_test.posts as p on (((u.id = p.user_id) and (p.is_deleted = 0))));
 		`,
 	)
 	assertApplyOutput(t, createTable+createView, applyPrefix+expected)
 	assertApplyOutput(t, createTable+createView, nothingModified)
 
-	assertApplyOutput(t, "", applyPrefix+"DROP TABLE `posts`;\nDROP TABLE `users`;\nDROP VIEW foo;\n")
+	assertApplyOutput(t, "", applyPrefix+"DROP TABLE `posts`;\nDROP TABLE `users`;\nDROP VIEW `foo`;\n")
 }
 
 func TestMysqldefDefaultValue(t *testing.T) {
@@ -1083,8 +1083,8 @@ func TestMysqldefDefaultValue(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE tools CHANGE COLUMN created_at created_at datetime NOT NULL DEFAULT current_timestamp;\n"+
-		"ALTER TABLE tools CHANGE COLUMN updated_at updated_at datetime NOT NULL DEFAULT current_timestamp ON UPDATE current_timestamp;\n")
+		"ALTER TABLE `tools` CHANGE COLUMN `created_at` `created_at` datetime NOT NULL DEFAULT current_timestamp;\n"+
+		"ALTER TABLE `tools` CHANGE COLUMN `updated_at` `updated_at` datetime NOT NULL DEFAULT current_timestamp ON UPDATE current_timestamp;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`
@@ -1098,8 +1098,8 @@ func TestMysqldefDefaultValue(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE tools CHANGE COLUMN created_at created_at datetime NOT NULL;\n"+
-		"ALTER TABLE tools CHANGE COLUMN updated_at updated_at datetime NOT NULL;\n")
+		"ALTER TABLE `tools` CHANGE COLUMN `created_at` `created_at` datetime NOT NULL;\n"+
+		"ALTER TABLE `tools` CHANGE COLUMN `updated_at` `updated_at` datetime NOT NULL;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -1122,7 +1122,7 @@ func TestMysqldefNegativeDefault(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE items CHANGE COLUMN position position float DEFAULT 100;\n")
+		"ALTER TABLE `items` CHANGE COLUMN `position` `position` float DEFAULT 100;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -1155,7 +1155,7 @@ func TestMysqldefIndexWithDot(t *testing.T) {
 		"  KEY `account.id`(account_id)\n" +
 		");\n"
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users ADD key `account.id`(`account_id`);\n")
+		"ALTER TABLE `users` ADD key `account.id`(`account_id`);\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -1180,10 +1180,10 @@ func TestMysqldefChangeIndexCombination(t *testing.T) {
 		"  KEY `index_users2`(account_id)\n" +
 		");\n"
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE users DROP INDEX `index_users1`;\n"+
-		"ALTER TABLE users ADD key `index_users1`(`account_id`, `name`);\n"+
-		"ALTER TABLE users DROP INDEX `index_users2`;\n"+
-		"ALTER TABLE users ADD key `index_users2`(`account_id`);\n")
+		"ALTER TABLE `users` DROP INDEX `index_users1`;\n"+
+		"ALTER TABLE `users` ADD key `index_users1`(`account_id`, `name`);\n"+
+		"ALTER TABLE `users` DROP INDEX `index_users2`;\n"+
+		"ALTER TABLE `users` ADD key `index_users2`(`account_id`);\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -80,7 +80,7 @@ func TestPsqldefCreateTableAlterColumn(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+stripHeredoc(`
-		ALTER TABLE public.users ALTER COLUMN name TYPE varchar(40);
+		ALTER TABLE "public"."users" ALTER COLUMN "name" TYPE varchar(40);
 		`,
 	))
 	assertApplyOutput(t, createTable, nothingModified)
@@ -124,8 +124,8 @@ func TestPsqldefCreateTablePrimaryKey(t *testing.T) {
 		);`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE public.users DROP CONSTRAINT users_pkey;\n"+
-		"ALTER TABLE public.users DROP COLUMN id;\n",
+		`ALTER TABLE "public"."users" DROP CONSTRAINT "users_pkey";`+"\n"+
+		`ALTER TABLE "public"."users" DROP COLUMN "id";`+"\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 
@@ -136,8 +136,8 @@ func TestPsqldefCreateTablePrimaryKey(t *testing.T) {
 		);`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+stripHeredoc(`
-		ALTER TABLE public.users ADD COLUMN id bigint NOT NULL;
-		ALTER TABLE public.users ADD primary key ("id");
+		ALTER TABLE "public"."users" ADD COLUMN "id" bigint NOT NULL;
+		ALTER TABLE "public"."users" ADD primary key ("id");
 		`,
 	))
 	assertApplyOutput(t, createTable, nothingModified)
@@ -166,7 +166,7 @@ func TestCreateTableForeignKey(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createUsers+createPosts, applyPrefix+
-		"ALTER TABLE public.posts ADD CONSTRAINT posts_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id);\n",
+		`ALTER TABLE "public"."posts" ADD CONSTRAINT "posts_ibfk_1" FOREIGN KEY ("user_id") REFERENCES "users" ("id");`+"\n",
 	)
 	assertApplyOutput(t, createUsers+createPosts, nothingModified)
 
@@ -179,8 +179,8 @@ func TestCreateTableForeignKey(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createUsers+createPosts, applyPrefix+
-		"ALTER TABLE public.posts DROP CONSTRAINT posts_ibfk_1;\n"+
-		"ALTER TABLE public.posts ADD CONSTRAINT posts_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL ON UPDATE CASCADE;\n",
+		`ALTER TABLE "public"."posts" DROP CONSTRAINT "posts_ibfk_1";`+"\n"+
+		`ALTER TABLE "public"."posts" ADD CONSTRAINT "posts_ibfk_1" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE;`+"\n",
 	)
 	assertApplyOutput(t, createUsers+createPosts, nothingModified)
 
@@ -191,7 +191,7 @@ func TestCreateTableForeignKey(t *testing.T) {
 		);
 		`,
 	)
-	assertApplyOutput(t, createUsers+createPosts, applyPrefix+"ALTER TABLE public.posts DROP CONSTRAINT posts_ibfk_1;\n")
+	assertApplyOutput(t, createUsers+createPosts, applyPrefix+`ALTER TABLE "public"."posts" DROP CONSTRAINT "posts_ibfk_1";`+"\n")
 	assertApplyOutput(t, createUsers+createPosts, nothingModified)
 }
 
@@ -225,8 +225,8 @@ func TestCreateTableWithReferences(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTableA+createTableB, applyPrefix+
-		"ALTER TABLE public.b DROP CONSTRAINT b_a_id_fkey;\n"+
-		"ALTER TABLE public.b DROP CONSTRAINT b_a_my_text_fkey;\n")
+		`ALTER TABLE "public"."b" DROP CONSTRAINT "b_a_id_fkey";`+"\n"+
+		`ALTER TABLE "public"."b" DROP CONSTRAINT "b_a_my_text_fkey";`+"\n")
 	assertApplyOutput(t, createTableA+createTableB, nothingModified)
 }
 
@@ -252,7 +252,7 @@ func TestCreatePolicy(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createUsers+createPolicy, applyPrefix+stripHeredoc(`
-		DROP POLICY p_users ON public.users;
+		DROP POLICY "p_users" ON "public"."users";
 		CREATE POLICY p_users ON users AS RESTRICTIVE FOR ALL TO postgres USING (id = (current_user)::integer);
 		`,
 	))
@@ -263,13 +263,13 @@ func TestCreatePolicy(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createUsers+createPolicy, applyPrefix+stripHeredoc(`
-		DROP POLICY p_users ON public.users;
+		DROP POLICY "p_users" ON "public"."users";
 		CREATE POLICY p_users ON users AS RESTRICTIVE FOR ALL TO postgres USING (true);
 		`,
 	))
 	assertApplyOutput(t, createUsers+createPolicy, nothingModified)
 
-	assertApplyOutput(t, createUsers, applyPrefix+"DROP POLICY p_users ON public.users;\n")
+	assertApplyOutput(t, createUsers, applyPrefix+`DROP POLICY "p_users" ON "public"."users";`+"\n")
 	assertApplyOutput(t, createUsers, nothingModified)
 }
 
@@ -296,12 +296,12 @@ func TestCreateView(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createUsers+createPosts+createView, applyPrefix+stripHeredoc(`
-		CREATE OR REPLACE VIEW view_user_posts AS select p.id from (posts as p join users as u on ((p.user_id = u.id))) where (p.is_deleted = false);
+		CREATE OR REPLACE VIEW "public"."view_user_posts" AS select p.id from (posts as p join users as u on ((p.user_id = u.id))) where (p.is_deleted = false);
 		`,
 	))
 	assertApplyOutput(t, createUsers+createPosts+createView, nothingModified)
 
-	assertApplyOutput(t, createUsers+createPosts, applyPrefix+"DROP VIEW view_user_posts;\n")
+	assertApplyOutput(t, createUsers+createPosts, applyPrefix+`DROP VIEW "public"."view_user_posts";`+"\n")
 	assertApplyOutput(t, createUsers+createPosts, nothingModified)
 }
 
@@ -320,7 +320,7 @@ func TestPsqldefDropPrimaryKey(t *testing.T) {
 		  name text
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE public.users DROP CONSTRAINT users_pkey;\n")
+	assertApplyOutput(t, createTable, applyPrefix+`ALTER TABLE "public"."users" DROP CONSTRAINT "users_pkey";`+"\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -344,7 +344,7 @@ func TestPsqldefAddColumn(t *testing.T) {
 		  age integer
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE public.users ADD COLUMN age integer;\n")
+	assertApplyOutput(t, createTable, applyPrefix+`ALTER TABLE "public"."users" ADD COLUMN "age" integer;`+"\n")
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`
@@ -353,7 +353,7 @@ func TestPsqldefAddColumn(t *testing.T) {
 		  age integer
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE public.users DROP COLUMN name;\n")
+	assertApplyOutput(t, createTable, applyPrefix+`ALTER TABLE "public"."users" DROP COLUMN name;`+"\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -375,7 +375,7 @@ func TestPsqldefAddArrayColumn(t *testing.T) {
 		  name integer[]
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE public.users ADD COLUMN name integer[];\n")
+	assertApplyOutput(t, createTable, applyPrefix+`ALTER TABLE "public"."users" ADD COLUMN "name" integer[];`+"\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -353,7 +353,7 @@ func TestPsqldefAddColumn(t *testing.T) {
 		  age integer
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+`ALTER TABLE "public"."users" DROP COLUMN name;`+"\n")
+	assertApplyOutput(t, createTable, applyPrefix+`ALTER TABLE "public"."users" DROP COLUMN "name";`+"\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -188,11 +188,13 @@ func TestMain(m *testing.M) {
 }
 
 func assertApply(t *testing.T, schema string) {
+	t.Helper()
 	writeFile("schema.sql", schema)
 	assertedExecute(t, "sqlite3def", "sqlite3def_test", "--file", "schema.sql")
 }
 
 func assertApplyOutput(t *testing.T, schema string, expected string) {
+	t.Helper()
 	writeFile("schema.sql", schema)
 	actual := assertedExecute(t, "sqlite3def", "sqlite3def_test", "--file", "schema.sql")
 	assertEquals(t, actual, expected)
@@ -207,6 +209,7 @@ func mustExecute(command string, args ...string) {
 }
 
 func assertedExecute(t *testing.T, command string, args ...string) string {
+	t.Helper()
 	out, err := execute(command, args...)
 	if err != nil {
 		t.Errorf("failed to execute '%s %s' (error: '%s'): `%s`", command, strings.Join(args, " "), err, out)
@@ -215,6 +218,7 @@ func assertedExecute(t *testing.T, command string, args ...string) string {
 }
 
 func assertEquals(t *testing.T, actual string, expected string) {
+	t.Helper()
 	if expected != actual {
 		t.Errorf("expected '%s' but got '%s'", expected, actual)
 	}

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -59,18 +59,18 @@ func TestSQLite3defCreateView(t *testing.T) {
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createView := stripHeredoc(`
-		CREATE VIEW view_users AS select id from users where age = 1;
+		CREATE VIEW ` + "`view_users`" + ` AS select id from users where age = 1;
 		`,
 	)
 	assertApplyOutput(t, createTable+createView, applyPrefix+createView)
 	assertApplyOutput(t, createTable+createView, nothingModified)
 
 	createView = stripHeredoc(`
-		CREATE VIEW view_users AS select id from users where age = 2;
+		CREATE VIEW ` + "`view_users`" + ` AS select id from users where age = 2;
 		`,
 	)
 	dropView := stripHeredoc(`
-		DROP VIEW view_users;
+		DROP VIEW ` + "`view_users`" + `;
 		`,
 	)
 	assertApplyOutput(t, createTable+createView, applyPrefix+dropView+createView)

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -40,7 +40,7 @@ func TestSQLite3defCreateTable(t *testing.T) {
 	assertApplyOutput(t, createTable1+createTable2, applyPrefix+createTable1+createTable2)
 	assertApplyOutput(t, createTable1+createTable2, nothingModified)
 
-	assertApplyOutput(t, createTable1, applyPrefix+"DROP TABLE `bigdata`;\n")
+	assertApplyOutput(t, createTable1, applyPrefix+`DROP TABLE "bigdata";`+"\n")
 	assertApplyOutput(t, createTable1, nothingModified)
 }
 
@@ -59,24 +59,24 @@ func TestSQLite3defCreateView(t *testing.T) {
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createView := stripHeredoc(`
-		CREATE VIEW ` + "`view_users`" + ` AS select id from users where age = 1;
+		CREATE VIEW "view_users" AS select id from users where age = 1;
 		`,
 	)
 	assertApplyOutput(t, createTable+createView, applyPrefix+createView)
 	assertApplyOutput(t, createTable+createView, nothingModified)
 
 	createView = stripHeredoc(`
-		CREATE VIEW ` + "`view_users`" + ` AS select id from users where age = 2;
+		CREATE VIEW "view_users" AS select id from users where age = 2;
 		`,
 	)
 	dropView := stripHeredoc(`
-		DROP VIEW ` + "`view_users`" + `;
+		DROP VIEW "view_users";
 		`,
 	)
 	assertApplyOutput(t, createTable+createView, applyPrefix+dropView+createView)
 	assertApplyOutput(t, createTable+createView, nothingModified)
 
-	assertApplyOutput(t, "", applyPrefix+"DROP TABLE `users`;\n"+dropView)
+	assertApplyOutput(t, "", applyPrefix+"DROP TABLE users;\n"+dropView)
 	//assertApplyOutput(t, "", nothingModified)
 }
 

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -40,7 +40,7 @@ func TestSQLite3defCreateTable(t *testing.T) {
 	assertApplyOutput(t, createTable1+createTable2, applyPrefix+createTable1+createTable2)
 	assertApplyOutput(t, createTable1+createTable2, nothingModified)
 
-	assertApplyOutput(t, createTable1, applyPrefix+`DROP TABLE "bigdata";`+"\n")
+	assertApplyOutput(t, createTable1, applyPrefix+"DROP TABLE `bigdata`;\n")
 	assertApplyOutput(t, createTable1, nothingModified)
 }
 
@@ -59,24 +59,24 @@ func TestSQLite3defCreateView(t *testing.T) {
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createView := stripHeredoc(`
-		CREATE VIEW "view_users" AS select id from users where age = 1;
+		CREATE VIEW ` + "`view_users`" + ` AS select id from users where age = 1;
 		`,
 	)
 	assertApplyOutput(t, createTable+createView, applyPrefix+createView)
 	assertApplyOutput(t, createTable+createView, nothingModified)
 
 	createView = stripHeredoc(`
-		CREATE VIEW "view_users" AS select id from users where age = 2;
+		CREATE VIEW ` + "`view_users`" + ` AS select id from users where age = 2;
 		`,
 	)
 	dropView := stripHeredoc(`
-		DROP VIEW "view_users";
+		DROP VIEW ` + "`view_users`" + `;
 		`,
 	)
 	assertApplyOutput(t, createTable+createView, applyPrefix+dropView+createView)
 	assertApplyOutput(t, createTable+createView, nothingModified)
 
-	assertApplyOutput(t, "", applyPrefix+"DROP TABLE users;\n"+dropView)
+	assertApplyOutput(t, "", applyPrefix+"DROP TABLE `users`;\n"+dropView)
 	//assertApplyOutput(t, "", nothingModified)
 }
 
@@ -188,13 +188,11 @@ func TestMain(m *testing.M) {
 }
 
 func assertApply(t *testing.T, schema string) {
-	t.Helper()
 	writeFile("schema.sql", schema)
 	assertedExecute(t, "sqlite3def", "sqlite3def_test", "--file", "schema.sql")
 }
 
 func assertApplyOutput(t *testing.T, schema string, expected string) {
-	t.Helper()
 	writeFile("schema.sql", schema)
 	actual := assertedExecute(t, "sqlite3def", "sqlite3def_test", "--file", "schema.sql")
 	assertEquals(t, actual, expected)
@@ -209,7 +207,6 @@ func mustExecute(command string, args ...string) {
 }
 
 func assertedExecute(t *testing.T, command string, args ...string) string {
-	t.Helper()
 	out, err := execute(command, args...)
 	if err != nil {
 		t.Errorf("failed to execute '%s %s' (error: '%s'): `%s`", command, strings.Join(args, " "), err, out)
@@ -218,7 +215,6 @@ func assertedExecute(t *testing.T, command string, args ...string) string {
 }
 
 func assertEquals(t *testing.T, actual string, expected string) {
-	t.Helper()
 	if expected != actual {
 		t.Errorf("expected '%s' but got '%s'", expected, actual)
 	}

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -292,7 +292,7 @@ func (g *Generator) generateDDLsForCreateTable(currentTable Table, desired Creat
 				ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP PRIMARY KEY", g.escapeTableName(desired.table.name)))
 			case GeneratorModePostgres:
 				tableName := strings.SplitN(desired.table.name, ".", 2)[1] // without schema
-				ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s_pkey", g.escapeTableName(desired.table.name), tableName))
+				ddls = append(ddls, fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT %s", g.escapeTableName(desired.table.name), g.escapeSQLName(tableName+"_pkey")))
 			default:
 			}
 		}

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -729,10 +729,10 @@ func (g *Generator) escapeTableName(name string) string {
 
 func (g *Generator) escapeSQLName(name string) string {
 	switch g.mode {
-	case GeneratorModeMysql:
-		return fmt.Sprintf("`%s`", name)
-	default:
+	case GeneratorModePostgres:
 		return fmt.Sprintf("\"%s\"", name)
+	default:
+		return fmt.Sprintf("`%s`", name)
 	}
 }
 

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -729,10 +729,10 @@ func (g *Generator) escapeTableName(name string) string {
 
 func (g *Generator) escapeSQLName(name string) string {
 	switch g.mode {
-	case GeneratorModePostgres:
-		return fmt.Sprintf("\"%s\"", name)
-	default:
+	case GeneratorModeMysql:
 		return fmt.Sprintf("`%s`", name)
+	default:
+		return fmt.Sprintf("\"%s\"", name)
 	}
 }
 

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -714,7 +714,14 @@ func (g *Generator) escapeTableName(name string) string {
 	switch g.mode {
 	case GeneratorModePostgres:
 		schemaTable := strings.SplitN(name, ".", 2)
-		return g.escapeSQLName(schemaTable[0]) + "." + g.escapeSQLName(schemaTable[1])
+		var schemaName, tableName string
+		if len(schemaTable) == 1 {
+			schemaName, tableName = "public", schemaTable[0]
+		} else {
+			schemaName, tableName = schemaTable[0], schemaTable[1]
+		}
+
+		return g.escapeSQLName(schemaName) + "." + g.escapeSQLName(tableName)
 	default:
 		return g.escapeSQLName(name)
 	}

--- a/sqlparser/token.go
+++ b/sqlparser/token.go
@@ -632,7 +632,7 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 				return tkn.scanString(ch, STRING)
 			}
 		default:
-			if tkn.mode == ParserModeMysql && ch == '`' {
+			if tkn.mode != ParserModePostgres && ch == '`' {
 				return tkn.scanLiteralIdentifier()
 			}
 			return LEX_ERROR, []byte{byte(ch)}


### PR DESCRIPTION
If the identifier is not escaped, an error will occur when handling the same table name or column name as the reserved word.
So I added a process to escape the identifier.

ref.
https://github.com/k0kubun/sqldef/commit/7e4a2dd53116551e9cb1d7e57f5d13a962c08e89