### PR TITLE
Support darwin/arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ package:
 	$(MAKE) package-targz GOOS=linux GOARCH=arm64
 	$(MAKE) package-targz GOOS=linux GOARCH=arm
 	$(MAKE) package-zip GOOS=darwin GOARCH=amd64
+	$(MAKE) package-zip GOOS=darwin GOARCH=arm64
 	$(MAKE) package-zip GOOS=windows GOARCH=amd64
 	$(MAKE) package-zip GOOS=windows GOARCH=386
 


### PR DESCRIPTION
Apple Silicon is supported in 1.16.
https://golang.org/doc/go1.16#darwin