### PR TITLE
fix postgres environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Usage:
 
 Application Options:
   -U, --user=username        PostgreSQL user name (default: postgres)
-  -W, --password=password    PostgreSQL user password, overridden by $PGPASS
+  -W, --password=password    PostgreSQL user password, overridden by $PGPASSWORD
   -h, --host=hostname        Host or socket directory to connect to the PostgreSQL server (default: 127.0.0.1)
   -p, --port=port            Port used for the connection (default: 5432)
       --password-prompt      Force PostgreSQL user password prompt

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -21,7 +21,7 @@ var version string
 func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	var opts struct {
 		User     string `short:"U" long:"user" description:"PostgreSQL user name" value-name:"username" default:"postgres"`
-		Password string `short:"W" long:"password" description:"PostgreSQL user password, overridden by $PGPASS" value-name:"password"`
+		Password string `short:"W" long:"password" description:"PostgreSQL user password, overridden by $PGPASSWORD" value-name:"password"`
 		Host     string `short:"h" long:"host" description:"Host or socket directory to connect to the PostgreSQL server" value-name:"hostname" default:"127.0.0.1"`
 		Port     uint   `short:"p" long:"port" description:"Port used for the connection" value-name:"port" default:"5432"`
 		Prompt   bool   `long:"password-prompt" description:"Force PostgreSQL user password prompt"`
@@ -68,7 +68,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		SkipDrop: opts.SkipDrop,
 	}
 
-	password, ok := os.LookupEnv("PGPASS")
+	password, ok := os.LookupEnv("PGPASSWORD")
 	if !ok {
 		password = opts.Password
 	}


### PR DESCRIPTION
I don't know if it's intentional implements that supporting `PGPASS` environment variable to set password on psqldef

The psql command used `PGPASSWORD` environment variable.

https://www.postgresql.org/docs/current/libpq-envars.html
> PGPASSWORD behaves the same as the password connection parameter. 

Should I support `PGPASS` for backward compatibility?
