### PR TITLE
mssqldef: support PRIMARY KEY

### DIFF
--- a/cmd/mssqldef/mssqldef_test.go
+++ b/cmd/mssqldef/mssqldef_test.go
@@ -302,6 +302,61 @@ func TestMssqldefCreateTableDropColumnWithPK(t *testing.T) {
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
+func TestMssqldefCreateTableAddPrimaryKey(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := stripHeredoc(`
+		CREATE TABLE users (
+		  id bigint NOT NULL,
+		  name varchar(20)
+		);
+		`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+createTable)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id bigint NOT NULL PRIMARY KEY,
+		  name varchar(20)
+		);
+		`,
+	)
+
+	assertApplyOutput(t, createTable, applyPrefix+
+		"ALTER TABLE [dbo].[users] ADD primary key CLUSTERED ([id]);\n",
+	)
+	assertApplyOutput(t, createTable, nothingModified)
+}
+
+func TestMssqldefCreateTableAddPrimaryKeyConstraint(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := stripHeredoc(`
+		CREATE TABLE users (
+		  id bigint NOT NULL,
+		  name varchar(20)
+		);
+		`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+createTable)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id bigint NOT NULL,
+		  name varchar(20),
+		  CONSTRAINT [pk_users] PRIMARY KEY CLUSTERED ([id])
+		);
+		`,
+	)
+
+	assertApplyOutput(t, createTable, applyPrefix+
+		"ALTER TABLE [dbo].[users] ADD CONSTRAINT [pk_users] primary key CLUSTERED ([id]);\n",
+	)
+	assertApplyOutput(t, createTable, nothingModified)
+}
+
 //
 // ----------------------- following tests are for CLI -----------------------
 //

--- a/cmd/mssqldef/mssqldef_test.go
+++ b/cmd/mssqldef/mssqldef_test.go
@@ -263,8 +263,8 @@ func TestMssqldefCreateTableDropColumnWithDefault(t *testing.T) {
 
 	// extract name of default constraint from sql server
 	out, err := execute("sqlcmd", "-Usa", "-PPassw0rd", "-dmssqldef_test", "-h", "-1", "-Q", stripHeredoc(`
-	SELECT OBJECT_NAME(c.default_object_id) FROM sys.columns c WHERE c.object_id = OBJECT_ID('dbo.users', 'U') AND c.default_object_id != 0;
-	`,
+		SELECT OBJECT_NAME(c.default_object_id) FROM sys.columns c WHERE c.object_id = OBJECT_ID('dbo.users', 'U') AND c.default_object_id != 0;
+		`,
 	))
 	if err != nil {
 		t.Error("failed to extract default object id")

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -81,6 +81,7 @@ type Index struct {
 	primary   bool
 	unique    bool
 	where     string // for Postgres `Partial Indexes`
+	clustered bool   // for MSSQL
 }
 
 type IndexColumn struct {
@@ -223,6 +224,7 @@ func (t *Table) PrimaryKey() *Index {
 		columns:   primaryColumns,
 		primary:   true,
 		unique:    true,
+		clustered: true,
 	}
 }
 

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -767,6 +767,18 @@ func (g *Generator) generateIndexDefinition(index Index) string {
 	}
 
 	if index.primary {
+		switch g.mode {
+		case GeneratorModeMssql:
+			if index.name != "PRIMARY" {
+				definition = fmt.Sprintf("CONSTRAINT %s %s", g.escapeSQLName(index.name), definition)
+			}
+
+			if !index.clustered {
+				definition += " NONCLUSTERED"
+			} else {
+				definition += " CLUSTERED"
+			}
+		}
 		definition += fmt.Sprintf(
 			" (%s)",
 			strings.Join(columns, ", "),

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -146,6 +146,7 @@ func parseTable(mode GeneratorMode, stmt *sqlparser.DDL) (Table, error) {
 			columns:   indexColumns,
 			primary:   indexDef.Info.Primary,
 			unique:    indexDef.Info.Unique,
+			clustered: bool(indexDef.Info.Clustered),
 		}
 		indexes = append(indexes, index)
 	}


### PR DESCRIPTION
This change supports the following features in sql server.
- ADD PRIMARY KEY
- DROP PRIMARY KEY