### PR TITLE
psqldef: Escape DSN parts & Add PGSSLROOTCERT support

### DIFF
--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -418,13 +418,17 @@ func postgresBuildDSN(config adapter.Config) string {
 		host = config.Socket
 	}
 
-	options := ""
+	var options []string
 	if sslmode, ok := os.LookupEnv("PGSSLMODE"); ok { // TODO: have this in adapter.Config, or standardize config with DSN?
-		options = fmt.Sprintf("?sslmode=%s", sslmode) // TODO: uri escape
+		options = append(options, fmt.Sprintf("sslmode=%s", sslmode)) // TODO: uri escape
+	}
+
+	if sslrootcert, ok := os.LookupEnv("PGSSLROOTCERT"); ok { // TODO: have this in adapter.Config, or standardize config with DSN?
+		options = append(options, fmt.Sprintf("sslrootcert=%s", sslrootcert))
 	}
 
 	// `QueryEscape` instead of `PathEscape` so that colon can be escaped.
-	return fmt.Sprintf("postgres://%s:%s@%s/%s%s", url.QueryEscape(user), url.QueryEscape(password), host, database, options)
+	return fmt.Sprintf("postgres://%s:%s@%s/%s?%s", url.QueryEscape(user), url.QueryEscape(password), host, database, strings.Join(options, "&"))
 }
 
 func splitTableName(table string) (string, string) {

--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
@@ -422,8 +423,8 @@ func postgresBuildDSN(config adapter.Config) string {
 		options = fmt.Sprintf("?sslmode=%s", sslmode) // TODO: uri escape
 	}
 
-	// TODO: uri escape
-	return fmt.Sprintf("postgres://%s:%s@%s/%s%s", user, password, host, database, options)
+	// `QueryEscape` instead of `PathEscape` so that colon can be escaped.
+	return fmt.Sprintf("postgres://%s:%s@%s/%s%s", url.QueryEscape(user), url.QueryEscape(password), host, database, options)
 }
 
 func splitTableName(table string) (string, string) {


### PR DESCRIPTION
### Escape DSN parts

Fixed the error on the DSN contains symbols.

```bash
$ export PGPASSWORD=".:?-&/%="
$ psqldef -U "user_.:?-&/%=" sandbox_db --skip-drop --file=test.sql
2021/07/02 16:26:34 Error on DumpDDLs: dial tcp: lookup user_.: no such host
```


### Add PGSSLROOTCERT support

https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT


I believe both of them are useful in case of AWS IAM Database Authentication. 🚀 