### PR TITLE
Migrate to GitHub Actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sqldef [![Build Status](https://travis-ci.org/k0kubun/sqldef.svg?branch=master)](https://travis-ci.org/k0kubun/sqldef)
+# sqldef [![sqldef](https://github.com/k0kubun/sqldef/actions/workflows/sqldef.yml/badge.svg)](https://github.com/k0kubun/sqldef/actions/workflows/sqldef.yml)
 
 The easiest idempotent MySQL/PostgreSQL/SQLite3/SQL Server schema management by SQL.
 


### PR DESCRIPTION
It looks like this repository is no longer using Travis CI.

So I migrated.