### PR TITLE
Support column comment

### DIFF
--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -332,10 +332,10 @@ func TestMysqldefAddColumn(t *testing.T) {
 		CREATE TABLE users (
 		  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 		  name varchar(40) DEFAULT NULL,
-		  created_at datetime NOT NULL
+		  created_at datetime NOT NULL COMMENT 'created time'
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `created_at` datetime NOT NULL AFTER `name`;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD COLUMN `created_at` datetime NOT NULL COMMENT 'created time' AFTER `name`;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -66,6 +66,7 @@ type Column struct {
 	timezone       bool // for Postgres `with time zone`
 	keyOption      ColumnKeyOption
 	onUpdate       *Value
+	comment        *Value
 	enumValues     []string
 	references     string
 	identity       *Identity

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -820,6 +820,10 @@ func (g *Generator) generateColumnDefinition(column Column, enableUnique bool) (
 		definition += fmt.Sprintf("ON UPDATE %s ", string(column.onUpdate.raw))
 	}
 
+	if column.comment != nil {
+		definition += fmt.Sprintf("COMMENT '%s' ", string(column.comment.raw))
+	}
+
 	if column.check != nil {
 		definition += "CHECK "
 		if column.check.notForReplication {

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -114,6 +114,7 @@ func parseTable(mode GeneratorMode, stmt *sqlparser.DDL) (Table, error) {
 			timezone:      castBool(parsedCol.Type.Timezone),
 			keyOption:     ColumnKeyOption(parsedCol.Type.KeyOpt), // FIXME: tight coupling in enum order
 			onUpdate:      parseValue(parsedCol.Type.OnUpdate),
+			comment:       parseValue(parsedCol.Type.Comment),
 			enumValues:    parsedCol.Type.EnumValues,
 			references:    parsedCol.Type.References,
 			identity:      parseIdentity(parsedCol.Type.Identity),


### PR DESCRIPTION
I want to add column with it's comment, so I suggest to add `COMMENT '...'` after `ON UPDATE` keyword.

I usually use only mysql, so if additional patch is needed, let me know anytime. :)

p.s. Thank you for maintaining this tool. I am using it to maintain our db schema as code like IaC.
