### PR TITLE
enable to get definition of view with same name, other database for mysql

### DIFF
--- a/adapter/mysql/mysql.go
+++ b/adapter/mysql/mysql.go
@@ -69,7 +69,7 @@ func (d *MysqlDatabase) Views() ([]string, error) {
 		if err = rows.Scan(&viewName, &viewType); err != nil {
 			return nil, err
 		}
-		query := fmt.Sprintf("select VIEW_DEFINITION from INFORMATION_SCHEMA.VIEWS where TABLE_NAME = '%s';", viewName)
+		query := fmt.Sprintf("select VIEW_DEFINITION from INFORMATION_SCHEMA.VIEWS where TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s';", d.config.DbName, viewName)
 		if err = d.db.QueryRow(query).Scan(&definition); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What
I added an extra where clause to specify view definition for mysqldef

## Why
 - We have view with the same name with different database.
 - Thus, I added the where clause to specify the view.