### PR TITLE
Support comparing --file options

### DIFF
--- a/adapter/database.go
+++ b/adapter/database.go
@@ -30,6 +30,7 @@ type Database interface {
 	Close() error
 }
 
+// TODO: This should probably be part of the Database interface
 func DumpDDLs(d Database) (string, error) {
 	ddls := []string{}
 

--- a/adapter/file/file.go
+++ b/adapter/file/file.go
@@ -1,0 +1,45 @@
+package file
+
+import (
+	"database/sql"
+	"github.com/k0kubun/sqldef"
+)
+
+// Pseudo adapter for comparison between files
+type FileDatabase struct {
+	file string
+}
+
+func NewDatabase(file string) FileDatabase {
+	return FileDatabase{
+		file: file,
+	}
+}
+
+func (f FileDatabase) TableNames() ([]string, error) {
+	return []string{f.file}, nil
+}
+
+func (f FileDatabase) DumpTableDDL(file string) (string, error) {
+	return sqldef.ReadFile(file)
+}
+
+func (f FileDatabase) Views() ([]string, error) {
+	return nil, nil
+}
+
+func (f FileDatabase) Triggers() ([]string, error) {
+	return nil, nil
+}
+
+func (f FileDatabase) Types() ([]string, error) {
+	return nil, nil
+}
+
+func (f FileDatabase) DB() *sql.DB {
+	return nil
+}
+
+func (f FileDatabase) Close() error {
+	return nil
+}

--- a/cmd/mssqldef/mssqldef.go
+++ b/cmd/mssqldef/mssqldef.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/k0kubun/sqldef/adapter/file"
 	"log"
 	"os"
 	"syscall"
@@ -20,17 +21,17 @@ var version string
 // TODO: Support `sqldef schema.sql -opt val...`
 func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	var opts struct {
-		User     string `short:"U" long:"user" description:"MSSQL user name" value-name:"user_name" default:"sa"`
-		Password string `short:"P" long:"password" description:"MSSQL user password, overridden by $MSSQL_PWD" value-name:"password"`
-		Host     string `short:"h" long:"host" description:"Host to connect to the MSSQL server" value-name:"host_name" default:"127.0.0.1"`
-		Port     uint   `short:"p" long:"port" description:"Port used for the connection" value-name:"port_num" default:"1433"`
-		Prompt   bool   `long:"password-prompt" description:"Force MSSQL user password prompt"`
-		File     string `long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
-		DryRun   bool   `long:"dry-run" description:"Don't run DDLs but just show them"`
-		Export   bool   `long:"export" description:"Just dump the current schema to stdout"`
-		SkipDrop bool   `long:"skip-drop" description:"Skip destructive changes such as DROP"`
-		Help     bool   `long:"help" description:"Show this help"`
-		Version  bool   `long:"version" description:"Show this version"`
+		User     string   `short:"U" long:"user" description:"MSSQL user name" value-name:"user_name" default:"sa"`
+		Password string   `short:"P" long:"password" description:"MSSQL user password, overridden by $MSSQL_PWD" value-name:"password"`
+		Host     string   `short:"h" long:"host" description:"Host to connect to the MSSQL server" value-name:"host_name" default:"127.0.0.1"`
+		Port     uint     `short:"p" long:"port" description:"Port used for the connection" value-name:"port_num" default:"1433"`
+		Prompt   bool     `long:"password-prompt" description:"Force MSSQL user password prompt"`
+		File     []string `long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
+		DryRun   bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Export   bool     `long:"export" description:"Just dump the current schema to stdout"`
+		SkipDrop bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
+		Help     bool     `long:"help" description:"Show this help"`
+		Version  bool     `long:"version" description:"Show this version"`
 	}
 
 	parser := flags.NewParser(&opts, flags.None)
@@ -50,22 +51,27 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		os.Exit(0)
 	}
 
-	if len(args) == 0 {
-		fmt.Print("No database is specified!\n\n")
-		parser.WriteHelp(os.Stdout)
-		os.Exit(1)
-	} else if len(args) > 1 {
-		fmt.Printf("Multiple databases are given: %v\n\n", args)
-		parser.WriteHelp(os.Stdout)
-		os.Exit(1)
-	}
-	database := args[0]
-
+	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
 	options := sqldef.Options{
-		SqlFile:  opts.File,
-		DryRun:   opts.DryRun,
-		Export:   opts.Export,
-		SkipDrop: opts.SkipDrop,
+		DesiredFile: desiredFile,
+		CurrentFile: currentFile,
+		DryRun:      opts.DryRun,
+		Export:      opts.Export,
+		SkipDrop:    opts.SkipDrop,
+	}
+
+	database := ""
+	if len(currentFile) == 0 {
+		if len(args) == 0 {
+			fmt.Print("No database is specified!\n\n")
+			parser.WriteHelp(os.Stdout)
+			os.Exit(1)
+		} else if len(args) > 1 {
+			fmt.Printf("Multiple databases are given: %v\n\n", args)
+			parser.WriteHelp(os.Stdout)
+			os.Exit(1)
+		}
+		database = args[0]
 	}
 
 	password, ok := os.LookupEnv("MSSQL_PWD")
@@ -95,11 +101,17 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 func main() {
 	config, options := parseOptions(os.Args[1:])
 
-	database, err := mssql.NewDatabase(config)
-	if err != nil {
-		log.Fatal(err)
+	var database adapter.Database
+	if len(options.CurrentFile) > 0 {
+		database = file.NewDatabase(options.CurrentFile)
+	} else {
+		var err error
+		database, err = mssql.NewDatabase(config)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer database.Close()
 	}
-	defer database.Close()
 
 	sqldef.Run(schema.GeneratorModeMssql, database, options)
 }

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/k0kubun/sqldef/adapter/file"
 	"log"
 	"os"
 	"syscall"
@@ -20,19 +21,19 @@ var version string
 // TODO: Support `sqldef schema.sql -opt val...`
 func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	var opts struct {
-		User                  string `short:"u" long:"user" description:"MySQL user name" value-name:"user_name" default:"root"`
-		Password              string `short:"p" long:"password" description:"MySQL user password, overridden by $MYSQL_PWD" value-name:"password"`
-		Host                  string `short:"h" long:"host" description:"Host to connect to the MySQL server" value-name:"host_name" default:"127.0.0.1"`
-		Port                  uint   `short:"P" long:"port" description:"Port used for the connection" value-name:"port_num" default:"3306"`
-		Socket                string `short:"S" long:"socket" description:"The socket file to use for connection" value-name:"socket"`
-		Prompt                bool   `long:"password-prompt" description:"Force MySQL user password prompt"`
-		EnableCleartextPlugin bool   `long:"enable-cleartext-plugin" description:"Enable/disable the clear text authentication plugin"`
-		File                  string `long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
-		DryRun                bool   `long:"dry-run" description:"Don't run DDLs but just show them"`
-		Export                bool   `long:"export" description:"Just dump the current schema to stdout"`
-		SkipDrop              bool   `long:"skip-drop" description:"Skip destructive changes such as DROP"`
-		Help                  bool   `long:"help" description:"Show this help"`
-		Version               bool   `long:"version" description:"Show this version"`
+		User                  string   `short:"u" long:"user" description:"MySQL user name" value-name:"user_name" default:"root"`
+		Password              string   `short:"p" long:"password" description:"MySQL user password, overridden by $MYSQL_PWD" value-name:"password"`
+		Host                  string   `short:"h" long:"host" description:"Host to connect to the MySQL server" value-name:"host_name" default:"127.0.0.1"`
+		Port                  uint     `short:"P" long:"port" description:"Port used for the connection" value-name:"port_num" default:"3306"`
+		Socket                string   `short:"S" long:"socket" description:"The socket file to use for connection" value-name:"socket"`
+		Prompt                bool     `long:"password-prompt" description:"Force MySQL user password prompt"`
+		EnableCleartextPlugin bool     `long:"enable-cleartext-plugin" description:"Enable/disable the clear text authentication plugin"`
+		File                  []string `long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
+		DryRun                bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
+		SkipDrop              bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
+		Help                  bool     `long:"help" description:"Show this help"`
+		Version               bool     `long:"version" description:"Show this version"`
 	}
 
 	parser := flags.NewParser(&opts, flags.None)
@@ -52,22 +53,27 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		os.Exit(0)
 	}
 
-	if len(args) == 0 {
-		fmt.Print("No database is specified!\n\n")
-		parser.WriteHelp(os.Stdout)
-		os.Exit(1)
-	} else if len(args) > 1 {
-		fmt.Printf("Multiple databases are given: %v\n\n", args)
-		parser.WriteHelp(os.Stdout)
-		os.Exit(1)
-	}
-	database := args[0]
-
+	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
 	options := sqldef.Options{
-		SqlFile:  opts.File,
-		DryRun:   opts.DryRun,
-		Export:   opts.Export,
-		SkipDrop: opts.SkipDrop,
+		DesiredFile: desiredFile,
+		CurrentFile: currentFile,
+		DryRun:      opts.DryRun,
+		Export:      opts.Export,
+		SkipDrop:    opts.SkipDrop,
+	}
+
+	database := ""
+	if len(currentFile) == 0 {
+		if len(args) == 0 {
+			fmt.Print("No database is specified!\n\n")
+			parser.WriteHelp(os.Stdout)
+			os.Exit(1)
+		} else if len(args) > 1 {
+			fmt.Printf("Multiple databases are given: %v\n\n", args)
+			parser.WriteHelp(os.Stdout)
+			os.Exit(1)
+		}
+		database = args[0]
 	}
 
 	password, ok := os.LookupEnv("MYSQL_PWD")
@@ -99,11 +105,17 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 func main() {
 	config, options := parseOptions(os.Args[1:])
 
-	database, err := mysql.NewDatabase(config)
-	if err != nil {
-		log.Fatal(err)
+	var database adapter.Database
+	if len(options.CurrentFile) > 0 {
+		database = file.NewDatabase(options.CurrentFile)
+	} else {
+		var err error
+		database, err = mysql.NewDatabase(config)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer database.Close()
 	}
-	defer database.Close()
 
 	sqldef.Run(schema.GeneratorModeMysql, database, options)
 }

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -1411,6 +1411,19 @@ func TestMysqldefChangeIndexCombination(t *testing.T) {
 // ----------------------- following tests are for CLI -----------------------
 //
 
+func TestMysqldefFileComparison(t *testing.T) {
+	resetTestDatabase()
+	writeFile("schema.sql", stripHeredoc(`
+		CREATE TABLE users (
+		  name varchar(40),
+		  created_at datetime NOT NULL
+		);`,
+	))
+
+	output := assertedExecute(t, "./mysqldef", "--file", "schema.sql", "--file", "schema.sql")
+	assertEquals(t, output, nothingModified)
+}
+
 func TestMysqldefDryRun(t *testing.T) {
 	resetTestDatabase()
 	writeFile("schema.sql", stripHeredoc(`


### PR DESCRIPTION
## Example
```
$ cat before.sql
CREATE TABLE users (
  id bigint PRIMARY KEY NOT NULL,
  created_at datetime NOT NULL
);

$ cat after.sql
CREATE TABLE users (
  id bigint PRIMARY KEY NOT NULL,
  name varchar(40) DEFAULT NULL,
  created_at datetime NOT NULL
);

$ mysqldef --file before.sql --file after.sql
-- dry run --
ALTER TABLE `users` ADD COLUMN `name` varchar(40) DEFAULT null AFTER `id`;
```