### PR TITLE
Fix bug that psqldef cannot handle CREATE TABLE with schema

### DIFF
--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -326,12 +326,13 @@ func (d *PostgresDatabase) getIndexDefs(table string) ([]string, error) {
 }
 
 func (d *PostgresDatabase) getCheckConstraints(tableName string) (map[string]string, error) {
-	const query = `SELECT conname, pg_get_constraintdef(c.oid, true)
-	FROM   pg_constraint c
-	JOIN   pg_namespace n ON n.oid = c.connamespace
-	WHERE  contype = 'c'
-	AND    n.nspname = $1
-	AND    conrelid::regclass = $2::regclass;`
+	const query = `SELECT con.conname, pg_get_constraintdef(con.oid, true)
+	FROM   pg_constraint con
+	JOIN   pg_namespace nsp ON nsp.oid = con.connamespace
+  JOIN   pg_class cls ON cls.oid = con.conrelid
+	WHERE  con.contype = 'c'
+	AND    nsp.nspname = $1
+	AND    cls.relname = $2;`
 
 	result := map[string]string{}
 	schema, table := splitTableName(tableName)
@@ -354,12 +355,13 @@ func (d *PostgresDatabase) getCheckConstraints(tableName string) (map[string]str
 }
 
 func (d *PostgresDatabase) getUniqueConstraints(tableName string) (map[string]string, error) {
-	const query = `SELECT conname, pg_get_constraintdef(c.oid)
-	FROM   pg_constraint c
-	JOIN   pg_namespace n ON n.oid = c.connamespace
-	WHERE  contype = 'u'
-	AND    n.nspname = $1
-	AND    conrelid::regclass = $2::regclass;`
+	const query = `SELECT con.conname, pg_get_constraintdef(con.oid)
+	FROM   pg_constraint con
+	JOIN   pg_namespace nsp ON nsp.oid = con.connamespace
+  JOIN   pg_class cls ON cls.oid = con.conrelid
+	WHERE  con.contype = 'u'
+	AND    nsp.nspname = $1
+	AND    cls.relname = $2;`
 
 	result := map[string]string{}
 	schema, table := splitTableName(tableName)

--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -329,7 +329,7 @@ func (d *PostgresDatabase) getCheckConstraints(tableName string) (map[string]str
 	const query = `SELECT con.conname, pg_get_constraintdef(con.oid, true)
 	FROM   pg_constraint con
 	JOIN   pg_namespace nsp ON nsp.oid = con.connamespace
-  JOIN   pg_class cls ON cls.oid = con.conrelid
+	JOIN   pg_class cls ON cls.oid = con.conrelid
 	WHERE  con.contype = 'c'
 	AND    nsp.nspname = $1
 	AND    cls.relname = $2;`
@@ -358,7 +358,7 @@ func (d *PostgresDatabase) getUniqueConstraints(tableName string) (map[string]st
 	const query = `SELECT con.conname, pg_get_constraintdef(con.oid)
 	FROM   pg_constraint con
 	JOIN   pg_namespace nsp ON nsp.oid = con.connamespace
-  JOIN   pg_class cls ON cls.oid = con.conrelid
+	JOIN   pg_class cls ON cls.oid = con.conrelid
 	WHERE  con.contype = 'u'
 	AND    nsp.nspname = $1
 	AND    cls.relname = $2;`

--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -140,7 +140,7 @@ func (d *PostgresDatabase) DumpTableDDL(table string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	foreginDefs, err := d.getForeginDefs(table)
+	foreignDefs, err := d.getForeignDefs(table)
 	if err != nil {
 		return "", err
 	}
@@ -152,10 +152,10 @@ func (d *PostgresDatabase) DumpTableDDL(table string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return buildDumpTableDDL(table, cols, pkeyCols, indexDefs, foreginDefs, policyDefs, checkConstraints), nil
+	return buildDumpTableDDL(table, cols, pkeyCols, indexDefs, foreignDefs, policyDefs, checkConstraints), nil
 }
 
-func buildDumpTableDDL(table string, columns []column, pkeyCols, indexDefs, foreginDefs, policyDefs []string, checkConstraints map[string]string) string {
+func buildDumpTableDDL(table string, columns []column, pkeyCols, indexDefs, foreignDefs, policyDefs []string, checkConstraints map[string]string) string {
 	var queryBuilder strings.Builder
 	fmt.Fprintf(&queryBuilder, "CREATE TABLE %s (", table)
 	for i, col := range columns {
@@ -189,7 +189,7 @@ func buildDumpTableDDL(table string, columns []column, pkeyCols, indexDefs, fore
 	for _, v := range indexDefs {
 		fmt.Fprintf(&queryBuilder, "%s;\n", v)
 	}
-	for _, v := range foreginDefs {
+	for _, v := range foreignDefs {
 		fmt.Fprintf(&queryBuilder, "%s;\n", v)
 	}
 	for _, v := range policyDefs {
@@ -410,7 +410,7 @@ WHERE constraint_type = 'PRIMARY KEY' AND tc.table_schema=$1 AND tc.table_name=$
 }
 
 // refs: https://gist.github.com/PickledDragon/dd41f4e72b428175354d
-func (d *PostgresDatabase) getForeginDefs(table string) ([]string, error) {
+func (d *PostgresDatabase) getForeignDefs(table string) ([]string, error) {
 	const query = `SELECT
 	tc.table_schema, tc.constraint_name, tc.table_name, kcu.column_name,
 	ccu.table_schema AS foreign_table_schema,

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -808,6 +808,15 @@ func TestPsqldefDataTypes(t *testing.T) {
 	assertApplyOutput(t, createTable, nothingModified) // Label for column type may change. Type will be examined.
 }
 
+func TestPsqldefCreateTableInSchema(t *testing.T) {
+	resetTestDatabase()
+	mustExecuteSQL("CREATE SCHEMA test;")
+
+	createTable := "CREATE TABLE test.users (id serial primary key);"
+	assertApplyOutput(t, createTable, applyPrefix+createTable+"\n")
+	assertApplyOutput(t, createTable, nothingModified)
+}
+
 //
 // ----------------------- following tests are for CLI -----------------------
 //

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -17,6 +18,7 @@ import (
 const (
 	applyPrefix     = "-- Apply --\n"
 	nothingModified = "-- Nothing is modified --\n"
+	database        = "psqldef_test"
 )
 
 func TestPsqldefCreateTable(t *testing.T) {
@@ -194,7 +196,7 @@ func TestPsqldefCreateTableNotNull(t *testing.T) {
 
 func TestPsqldefCitextExtension(t *testing.T) {
 	resetTestDatabase()
-	mustExecute("psql", "-Upostgres", "psqldef_test", "-c", "CREATE EXTENSION citext;")
+	mustExecuteSQL("CREATE EXTENSION citext;")
 
 	createTable := stripHeredoc(`
 		CREATE TABLE users (
@@ -205,13 +207,13 @@ func TestPsqldefCitextExtension(t *testing.T) {
 	assertApplyOutput(t, createTable, applyPrefix+createTable)
 	assertApplyOutput(t, createTable, nothingModified)
 
-	mustExecute("psql", "-Upostgres", "psqldef_test", "-c", "DROP TABLE users;")
-	mustExecute("psql", "-Upostgres", "psqldef_test", "-c", "DROP EXTENSION citext;")
+	mustExecuteSQL("DROP TABLE users;")
+	mustExecuteSQL("DROP EXTENSION citext;")
 }
 
 func TestPsqldefIgnoreExtension(t *testing.T) {
 	resetTestDatabase()
-	mustExecute("psql", "-Upostgres", "psqldef_test", "-c", "CREATE EXTENSION pg_buffercache;")
+	mustExecuteSQL("CREATE EXTENSION pg_buffercache;")
 
 	createTable := stripHeredoc(`
 		CREATE TABLE users (
@@ -225,7 +227,7 @@ func TestPsqldefIgnoreExtension(t *testing.T) {
 	assertApplyOutput(t, createTable, applyPrefix+createTable)
 	assertApplyOutput(t, createTable, nothingModified)
 
-	mustExecute("psql", "-Upostgres", "psqldef_test", "-c", "DROP EXTENSION pg_buffercache;")
+	mustExecuteSQL("DROP EXTENSION pg_buffercache;")
 }
 
 func TestPsqldefCreateTablePrimaryKey(t *testing.T) {
@@ -819,14 +821,14 @@ func TestPsqldefDryRun(t *testing.T) {
 	    );`,
 	))
 
-	dryRun := assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--dry-run", "--file", "schema.sql")
-	apply := assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--file", "schema.sql")
+	dryRun := assertedExecute(t, "./psqldef", "-Upostgres", database, "--dry-run", "--file", "schema.sql")
+	apply := assertedExecute(t, "./psqldef", "-Upostgres", database, "--file", "schema.sql")
 	assertEquals(t, dryRun, strings.Replace(apply, "Apply", "dry run", 1))
 }
 
 func TestPsqldefSkipDrop(t *testing.T) {
 	resetTestDatabase()
-	mustExecute("psql", "-Upostgres", "psqldef_test", "-c", stripHeredoc(`
+	mustExecuteSQL(stripHeredoc(`
 		CREATE TABLE users (
 		    id bigint NOT NULL PRIMARY KEY,
 		    age int,
@@ -839,17 +841,17 @@ func TestPsqldefSkipDrop(t *testing.T) {
 
 	writeFile("schema.sql", "")
 
-	skipDrop := assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--skip-drop", "--file", "schema.sql")
-	apply := assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--file", "schema.sql")
+	skipDrop := assertedExecute(t, "./psqldef", "-Upostgres", database, "--skip-drop", "--file", "schema.sql")
+	apply := assertedExecute(t, "./psqldef", "-Upostgres", database, "--file", "schema.sql")
 	assertEquals(t, skipDrop, strings.Replace(apply, "DROP", "-- Skipped: DROP", 1))
 }
 
 func TestPsqldefExport(t *testing.T) {
 	resetTestDatabase()
-	out := assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--export")
+	out := assertedExecute(t, "./psqldef", "-Upostgres", database, "--export")
 	assertEquals(t, out, "-- No table exists --\n")
 
-	mustExecute("psql", "-Upostgres", "psqldef_test", "-c", stripHeredoc(`
+	mustExecuteSQL(stripHeredoc(`
 		CREATE TABLE users (
 		    id bigint NOT NULL PRIMARY KEY,
 		    age int,
@@ -859,7 +861,7 @@ func TestPsqldefExport(t *testing.T) {
 		    c_varchar_unlimited varchar
 		);`,
 	))
-	out = assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--export")
+	out = assertedExecute(t, "./psqldef", "-Upostgres", database, "--export")
 	// workaround: local has `public.` but travis doesn't.
 	assertEquals(t, strings.Replace(out, "public.users", "users", 2), stripHeredoc(`
 		CREATE TABLE users (
@@ -878,10 +880,10 @@ func TestPsqldefExport(t *testing.T) {
 
 func TestPsqldefExportCompositePrimaryKey(t *testing.T) {
 	resetTestDatabase()
-	out := assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--export")
+	out := assertedExecute(t, "./psqldef", "-Upostgres", database, "--export")
 	assertEquals(t, out, "-- No table exists --\n")
 
-	mustExecute("psql", "-Upostgres", "psqldef_test", "-c", stripHeredoc(`
+	mustExecuteSQL(stripHeredoc(`
 		CREATE TABLE users (
 		    col1 character varying(40) NOT NULL,
 		    col2 character varying(6) NOT NULL,
@@ -889,7 +891,7 @@ func TestPsqldefExportCompositePrimaryKey(t *testing.T) {
 		    PRIMARY KEY (col1, col2)
 		);`,
 	))
-	out = assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--export")
+	out = assertedExecute(t, "./psqldef", "-Upostgres", database, "--export")
 	// workaround: local has `public.` but travis doesn't.
 	assertEquals(t, strings.Replace(out, "public.users", "users", 2), stripHeredoc(`
 		CREATE TABLE users (
@@ -1111,13 +1113,13 @@ func TestMain(m *testing.M) {
 func assertApply(t *testing.T, schema string) {
 	t.Helper()
 	writeFile("schema.sql", schema)
-	assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--file", "schema.sql")
+	assertedExecute(t, "./psqldef", "-Upostgres", database, "--file", "schema.sql")
 }
 
 func assertApplyOutput(t *testing.T, schema string, expected string) {
 	t.Helper()
 	writeFile("schema.sql", schema)
-	actual := assertedExecute(t, "./psqldef", "-Upostgres", "psqldef_test", "--file", "schema.sql")
+	actual := assertedExecute(t, "./psqldef", "-Upostgres", database, "--file", "schema.sql")
 	assertEquals(t, actual, expected)
 }
 
@@ -1127,6 +1129,10 @@ func mustExecute(command string, args ...string) {
 		log.Printf("failed to execute '%s %s': `%s`", command, strings.Join(args, " "), out)
 		log.Fatal(err)
 	}
+}
+
+func mustExecuteSQL(sql string) {
+	mustExecute("psql", "-Upostgres", database, "-c", sql)
 }
 
 func assertedExecute(t *testing.T, command string, args ...string) string {
@@ -1152,8 +1158,8 @@ func execute(command string, args ...string) (string, error) {
 }
 
 func resetTestDatabase() {
-	mustExecute("psql", "-Upostgres", "-c", "DROP DATABASE IF EXISTS psqldef_test;")
-	mustExecute("psql", "-Upostgres", "-c", "CREATE DATABASE psqldef_test;")
+	mustExecute("psql", "-Upostgres", "-c", fmt.Sprintf("DROP DATABASE IF EXISTS %s;", database))
+	mustExecute("psql", "-Upostgres", "-c", fmt.Sprintf("CREATE DATABASE %s;", database))
 }
 
 func writeFile(path string, content string) {


### PR DESCRIPTION
By v0.11.23, psqldef cannot handle DDL like this:

```sql
CREATE TABLE test.users (id serial primary key);
--           ^^^^^
```

This PR fixes the issue.

#### Chore

This PR also

* refactors psqldef_test.go a bit:
  * Define the name of test database as constant variable and reuse it in favor of DRY.
  * Hide the detail of how SQLs are submitted to a Postgres server from each test case.
* fixes typo: foregin → foreign