### PR TITLE
Add postgres 13 and 14 to CI test matrix

### DIFF
--- a/.github/workflows/sqldef.yml
+++ b/.github/workflows/sqldef.yml
@@ -26,6 +26,10 @@ jobs:
             version: 11
           - database: psql
             version: 12
+          - database: psql
+            version: 13
+          - database: psql
+            version: 14
       fail-fast: false
     steps:
       - uses: actions/setup-go@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - '3306:3306'
   postgres:
-    image: postgres:${POSTGRES_VERSION:-12}
+    image: postgres:${POSTGRES_VERSION:-14}
     environment:
       POSTGRES_USER: postgres
       POSTGRES_HOST_AUTH_METHOD: trust


### PR DESCRIPTION
https://github.com/k0kubun/sqldef/pull/188#issuecomment-1019416908

This PR also updates the default postgres version used in development from 12 to 14.