### PR TITLE
Fix bug that psqldef attempts to drop&add pk every time if two tables have same name and pk

### DIFF
--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -389,7 +389,7 @@ func (d *PostgresDatabase) getPrimaryKeyColumns(table string) ([]string, error) 
 FROM
 	information_schema.table_constraints AS tc
 	JOIN information_schema.key_column_usage AS kcu
-		ON tc.constraint_name = kcu.constraint_name
+		USING (table_schema, table_name, constraint_name)
 WHERE constraint_type = 'PRIMARY KEY' AND tc.table_schema=$1 AND tc.table_name=$2 ORDER BY kcu.ordinal_position`
 	schema, table := SplitTableName(table)
 	rows, err := d.db.Query(query, schema, table)

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -864,6 +864,17 @@ func TestPsqldefCheckConstraintInSchema(t *testing.T) {
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
+func TestPsqldefSameTableNameAmongSchemas(t *testing.T) {
+	resetTestDatabase()
+	mustExecuteSQL("CREATE SCHEMA test;")
+
+	createTable := stripHeredoc(`
+		CREATE TABLE dummy (id int primary key);
+		CREATE TABLE test.dummy (id int primary key);`)
+	assertApplyOutput(t, createTable, applyPrefix+createTable+"\n")
+	assertApplyOutput(t, createTable, nothingModified)
+}
+
 //
 // ----------------------- following tests are for CLI -----------------------
 //


### PR DESCRIPTION
Suppose there are two tables having:

* same table name
* same primary key column name

```sql
-- e.g.
create table user.accounts (id int primary key);
create table bank.accounts (id int primary key);
```

psqldef generates following DDL every time:

```sql
-- Apply --
ALTER TABLE "user"."accounts" DROP CONSTRAINT "accounts_pkey";
ALTER TABLE "user"."accounts" ADD primary key ("id");
ALTER TABLE "bank"."accounts" DROP CONSTRAINT "accounts_pkey";
ALTER TABLE "bank"."accounts" ADD primary key ("id");
```

This PR fixes this issue.