### PR TITLE
Enable to drop a column even if there is similar column in other schema

### DIFF
--- a/adapter/postgres/postgres.go
+++ b/adapter/postgres/postgres.go
@@ -246,7 +246,7 @@ FROM pg_attribute f
 	JOIN pg_class c ON c.oid = f.attrelid JOIN pg_type t ON t.oid = f.atttypid
 	LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = f.attnum
 	LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
-	LEFT JOIN information_schema.columns s ON s.column_name=f.attname AND s.table_name = c.relname
+	LEFT JOIN information_schema.columns s ON s.column_name=f.attname AND s.table_name = c.relname AND s.table_schema = n.nspname
 WHERE c.relkind = 'r'::char AND n.nspname = $1 AND c.relname = $2 AND f.attnum > 0 ORDER BY f.attnum;`
 
 	schema, table := SplitTableName(table)

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -869,9 +869,15 @@ func TestPsqldefSameTableNameAmongSchemas(t *testing.T) {
 	mustExecuteSQL("CREATE SCHEMA test;")
 
 	createTable := stripHeredoc(`
-		CREATE TABLE dummy (id int primary key);
-		CREATE TABLE test.dummy (id int primary key);`)
+		CREATE TABLE dummy (id int);
+		CREATE TABLE test.dummy (id int);`)
 	assertApplyOutput(t, createTable, applyPrefix+createTable+"\n")
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE dummy (id int);
+		CREATE TABLE test.dummy ();`)
+	assertApplyOutput(t, createTable, applyPrefix+`ALTER TABLE "test"."dummy" DROP COLUMN "id";`+"\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 


### PR DESCRIPTION
Suppose there are two similar tables in two schemas:

```sql
create table user.accounts (id int);
create table bank.accounts (id int);
```

If we drop a column from a table:

```sql
create table user.accounts (id int);
create table bank.accounts ();
```

`psqldef` generates duplicated `drop column`:

```
-- Apply --
ALTER TABLE "bank"."accounts" DROP COLUMN "id";
ALTER TABLE "bank"."accounts" DROP COLUMN "id";
```

This PR fixes the issue.