### PR TITLE
Enable to add a unique constraint to tables in non-public schema

### DIFF
--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -918,19 +918,25 @@ func TestPsqldefCheckConstraintInSchema(t *testing.T) {
 
 	createTable = stripHeredoc(`
 		CREATE TABLE test.dummy (
-		  min_value INT CONSTRAINT min_value_check CHECK (min_value > 0),
+		  min_value INT CHECK (min_value > 0),
 		  max_value INT CHECK (max_value > 0),
 		  CONSTRAINT min_max CHECK (min_value < max_value)
 		);`)
 	assertApplyOutput(t, createTable, applyPrefix+
-		`ALTER TABLE "test"."dummy" ADD CONSTRAINT min_value_check CHECK (min_value > 0);`+"\n"+
 		`ALTER TABLE "test"."dummy" ADD CONSTRAINT dummy_max_value_check CHECK (max_value > 0);`+"\n"+
 		`ALTER TABLE "test"."dummy" ADD CONSTRAINT "min_max" CHECK (min_value < max_value);`+"\n")
+	assertExportOutput(t, stripHeredoc(`
+		CREATE TABLE test.dummy (
+		    "min_value" integer CONSTRAINT dummy_min_value_check CHECK (min_value > 0),
+		    "max_value" integer CONSTRAINT dummy_max_value_check CHECK (max_value > 0),
+		    CONSTRAINT min_max CHECK (min_value < max_value)
+		);
+		`))
 	assertApplyOutput(t, createTable, nothingModified)
 
 	createTable = stripHeredoc(`
 		CREATE TABLE test.dummy (
-		  min_value INT CONSTRAINT min_value_check CHECK (min_value > 0),
+		  min_value INT CHECK (min_value > 0),
 		  max_value INT
 		);`)
 	assertApplyOutput(t, createTable, applyPrefix+


### PR DESCRIPTION
Fixes the bug I mentioned in https://github.com/k0kubun/sqldef/pull/196#issuecomment-1024840782

> * Bug fixes
>   * (high priority): `alter table non_public.foo add constraint uniq unique (col);` always generate `DROP INDEX uniq;` and it causes `pg: index "uniq" does not exist.`
>     * why high?: the table storing slack installation JSON lives in non public schema.

This PR also includes two chore commits:
1. c693d02031234f590f6ccd26b04f261f0ac7e805 While addressing the issue, I needed to check the result of `--export` many times, so I added `assertExportOutput()` helper and refactored psqldef_test.go a bit.
2. 31542f5661b80b6585bebdde266cb5109ab90d72 When I tested the `assertExportOutput()`, I found a bug in the test case added by #196
    * It was a test of a situation that rarely happens, so I simply dropped it.

NOTE: As I explained in https://github.com/k0kubun/sqldef/pull/196#issuecomment-1024840782, I'm planning to send one more pull request for the other high priority issue for me in the near future.