### PR TITLE
Introduce a YAML-based test framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,8 +479,17 @@ $ sudo apt-get update && sudo apt-get install mssql-tools # then add: export PAT
 $ brew install libpq && brew link --force libpq
 $ brew install microsoft/mssql-release/mssql-tools
 
+# Start database
 $ docker-compose up
+
+# Run all tests
 $ make test
+
+# Run *def tests
+$ go test ./cmd/*def
+
+# Run a single test
+$ go test ./cmd/mysqldef -run=TestGenerate/CreateTable
 ```
 
 ## Contributing

--- a/cmd/mssqldef/tests/create_table.yml
+++ b/cmd/mssqldef/tests/create_table.yml
@@ -1,0 +1,12 @@
+CreateTable:
+  desired: |
+    CREATE TABLE bigdata (
+      data bigint
+    );
+DropTable:
+  current: |
+    CREATE TABLE bigdata (
+      data bigint
+    );
+  output: |
+    DROP TABLE [dbo].[bigdata];

--- a/cmd/mysqldef/tests/create_table.yml
+++ b/cmd/mysqldef/tests/create_table.yml
@@ -1,0 +1,14 @@
+CreateTable:
+  desired: |
+    CREATE TABLE users (
+      id bigint UNSIGNED NOT NULL,
+      name varchar(40) DEFAULT null,
+      created_at datetime NOT NULL
+    );
+DropTable:
+  current: |
+    CREATE TABLE bigdata (
+      data bigint(20)
+    );
+  output: |
+    DROP TABLE `bigdata`;

--- a/cmd/psqldef/tests/create_table.yml
+++ b/cmd/psqldef/tests/create_table.yml
@@ -1,0 +1,12 @@
+CreateTable:
+  desired: |
+    CREATE TABLE public.bigdata (
+      data bigint
+    );
+DropTable:
+  current: |
+    CREATE TABLE public.bigdata (
+      data bigint
+    );
+  output: |
+    DROP TABLE "public"."bigdata";

--- a/cmd/sqlite3def/tests/create_table.yml
+++ b/cmd/sqlite3def/tests/create_table.yml
@@ -1,0 +1,12 @@
+CreateTable:
+  desired: |
+    CREATE TABLE bigdata (
+      data bigint
+    );
+DropTable:
+  current: |
+    CREATE TABLE bigdata (
+      data bigint
+    );
+  output: |
+    DROP TABLE `bigdata`;

--- a/cmd/testutils/testutils.go
+++ b/cmd/testutils/testutils.go
@@ -1,0 +1,94 @@
+// Utilities for _test.go files
+package testutils
+
+import (
+	"fmt"
+	"github.com/k0kubun/sqldef/adapter"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type TestCase struct {
+	Current string // default: empty schema
+	Desired string // default: empty schema
+	Output  string // default: use Desired as Output
+}
+
+func ReadTests(pattern string) (map[string]TestCase, error) {
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := map[string]TestCase{}
+	for _, file := range files {
+		var tests map[string]*TestCase
+
+		buf, err := ioutil.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+
+		err = yaml.UnmarshalStrict(buf, &tests)
+		if err != nil {
+			return nil, err
+		}
+
+		for name, test := range tests {
+			if test.Output == "" {
+				test.Output = test.Desired
+			}
+			if _, ok := ret[name]; ok {
+				log.Fatal(fmt.Sprintf("There are multiple test cases named '%s'", name))
+			}
+			ret[name] = *test
+		}
+	}
+
+	return ret, nil
+}
+
+func RunDDLs(db adapter.Database, ddls []string) error {
+	transaction, err := db.DB().Begin()
+	if err != nil {
+		return err
+	}
+	for _, ddl := range ddls {
+		if _, err := transaction.Exec(ddl); err != nil {
+			rollbackErr := transaction.Rollback()
+			if rollbackErr != nil {
+				return rollbackErr
+			}
+			return err
+		}
+	}
+	return transaction.Commit()
+}
+
+func JoinDDLs(ddls []string) string {
+	var builder strings.Builder
+	for _, ddl := range ddls {
+		builder.WriteString(ddl)
+		builder.WriteString(";\n")
+	}
+	return builder.String()
+}
+
+func MustExecute(command string, args ...string) string {
+	out, err := execute(command, args...)
+	if err != nil {
+		log.Printf("failed to execute '%s %s': `%s`", command, strings.Join(args, " "), out)
+		log.Fatal(err)
+	}
+	return out
+}
+
+func execute(command string, args ...string) (string, error) {
+	cmd := exec.Command(command, args...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/lib/pq v1.10.4
 	github.com/mattn/go-sqlite3 v1.14.11
 	golang.org/x/term v0.0.0-20210406210042-72f3dc4e9b72
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,7 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/sqldef.go
+++ b/sqldef.go
@@ -40,7 +40,7 @@ func Run(generatorMode schema.GeneratorMode, db adapter.Database, options *Optio
 	if err != nil {
 		log.Fatalf("Failed to read '%s': %s", options.DesiredFile, err)
 	}
-	desiredDDLs := string(sql)
+	desiredDDLs := sql
 
 	ddls, err := schema.GenerateIdempotentDDLs(generatorMode, desiredDDLs, currentDDLs)
 	if err != nil {


### PR DESCRIPTION
* Address difficulty of writing sqldef tests in Go
  * Using `"` vs <code>`</code> for escaping identifiers while both are also needed for Go string literal
  * Tabs and spaces in indentation
* Accelerate test execution by not invoking sqldef commands every time
  * Migrating existing tests to the framework is to be done in other commits
  * mysqldef tests also reuse the same DB connection for all tests
* Eliminate repetition of test codes
  * e.g. `resetTestDatabase`, `nothingModified` for the second apply