### PR TITLE
Add features to avoid environmental dependence

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Application Options:
       --export                      Just dump the current schema to stdout
       --skip-drop                   Skip destructive changes such as DROP
       --without-partition-range     Without the specific code of PARTITION BY RANGE
+      --init-auto-increment         Initialize AUTO_INCREMENT for CREATE TABLE
       --help                        Show this help
       --version                     Show this version
 ```
@@ -125,6 +126,33 @@ CREATE TABLE user (
 ```sql
 $ mysqldef -uroot test --export > schema.sql
 $ mysqldef -uroot test --dry-run --without-partition-range < schema.sql
+Run: 
+CREATE TABLE user (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(128) DEFAULT 'k0kubun',
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+##### --init-auto-increment
+```sql
+# original schema
+CREATE TABLE user (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(128) DEFAULT 'k0kubun',
+) Engine=InnoDB AUTO_INCREMENT=123 DEFAULT CHARSET=utf8mb4;
+```
+
+```sql
+$ mysqldef -uroot test --export --init-auto-increment > schema.sql
+CREATE TABLE user (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(128) DEFAULT 'k0kubun',
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+```sql
+$ mysqldef -uroot test --export > schema.sql
+$ mysqldef -uroot test --dry-run --init-auto-increment < schema.sql
 Run: 
 CREATE TABLE user (
   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Application Options:
       --dry-run                     Don't run DDLs but just show them
       --export                      Just dump the current schema to stdout
       --skip-drop                   Skip destructive changes such as DROP
+      --without-partition-range     Without the specific code of PARTITION BY RANGE
       --help                        Show this help
       --version                     Show this version
 ```
@@ -96,6 +97,39 @@ Nothing is modified
 # Run without droping existing tables and columns
 $ mysqldef -uroot test --skip-drop < schema.sql
 Skipped: 'DROP TABLE users;'
+```
+
+#### Options to avoid environment dependence
+
+##### --without-partition-range
+```sql
+# original schema
+CREATE TABLE user (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(128) DEFAULT 'k0kubun',
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4
+/*!50100 PARTITION BY RANGE (`id`)
+(PARTITION p0 VALUES LESS THAN (5) ENGINE = InnoDB,
+ PARTITION p1 VALUES LESS THAN (10) ENGINE = InnoDB,
+ PARTITION p2 VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */;
+```
+
+```sql
+$ mysqldef -uroot test --export --without-partition-range > schema.sql
+CREATE TABLE user (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(128) DEFAULT 'k0kubun',
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+```sql
+$ mysqldef -uroot test --export > schema.sql
+$ mysqldef -uroot test --dry-run --without-partition-range < schema.sql
+Run: 
+CREATE TABLE user (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(128) DEFAULT 'k0kubun',
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4;
 ```
 
 ### psqldef

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Application Options:
       --skip-drop                   Skip destructive changes such as DROP
       --without-partition-range     Without the specific code of PARTITION BY RANGE
       --init-auto-increment         Initialize AUTO_INCREMENT for CREATE TABLE
+      --targets                     Manage the target name (Table, View, Type, Trigger)
+      --target-file                 File management of --targets option
       --help                        Show this help
       --version                     Show this version
 ```
@@ -101,6 +103,31 @@ Skipped: 'DROP TABLE users;'
 ```
 
 #### Options to avoid environment dependence
+These options may be useful when running in different environments (e.g. stg <->prod)
+
+##### --targets, --target-file
+Tables other than users, orders, mails are ignored
+
+```sql
+$ mysqldef -uroot test --targets users,orders,mails --export > schema.sql
+
+$ mysqldef -uroot test --targets users,orders,mails < schema.sql
+```
+
+The following works the same as the command above
+
+```plaintext
+# Save as file with the name `tables_file`
+users
+orders
+mails
+```
+
+```sql
+$ mysqldef -uroot test --target-file tables_file --export > schema.sql
+
+$ mysqldef -uroot test --target-file tables_file < schema.sql
+```
 
 ##### --without-partition-range
 ```sql
@@ -179,6 +206,8 @@ Application Options:
       --dry-run              Don't run DDLs but just show them
       --export               Just dump the current schema to stdout
       --skip-drop            Skip destructive changes such as DROP
+      --targets              Manage the target name (Table, View, Type, Trigger)
+      --target-file          File management of --targets option
       --help                 Show this help
 ```
 
@@ -259,6 +288,8 @@ Application Options:
       --dry-run          Don't run DDLs but just show them
       --export           Just dump the current schema to stdout
       --skip-drop        Skip destructive changes such as DROP
+      --targets          Manage the target name (Table, View, Type, Trigger)
+      --target-file      File management of --targets option
       --help             Show this help
 ```
 
@@ -278,6 +309,8 @@ Application Options:
       --dry-run              Don't run DDLs but just show them
       --export               Just dump the current schema to stdout
       --skip-drop            Skip destructive changes such as DROP
+      --targets              Manage the target name (Table, View, Type, Trigger)
+      --target-file          File management of --targets option
       --help                 Show this help
       --version              Show this version
 ```

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -33,6 +33,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
 		SkipDrop              bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
 		WithoutPartitionRange bool     `long:"without-partition-range" description:"Without the specific code of PARTITION BY RANGE"`
+		InitAutoIncrement     bool     `long:"init-auto-increment" description:"Initialize AUTO_INCREMENT for CREATE TABLE"`
 		Help                  bool     `long:"help" description:"Show this help"`
 		Version               bool     `long:"version" description:"Show this version"`
 	}
@@ -62,6 +63,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		Export:                opts.Export,
 		SkipDrop:              opts.SkipDrop,
 		WithoutPartitionRange: opts.WithoutPartitionRange,
+		InitAutoIncrement:     opts.InitAutoIncrement,
 	}
 
 	database := ""

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/k0kubun/sqldef/adapter/file"
 	"log"
 	"os"
 	"syscall"
@@ -10,6 +9,7 @@ import (
 	"github.com/jessevdk/go-flags"
 	"github.com/k0kubun/sqldef"
 	"github.com/k0kubun/sqldef/adapter"
+	"github.com/k0kubun/sqldef/adapter/file"
 	"github.com/k0kubun/sqldef/adapter/mysql"
 	"github.com/k0kubun/sqldef/schema"
 	"golang.org/x/term"
@@ -32,6 +32,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		DryRun                bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
 		SkipDrop              bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
+		WithoutPartitionRange bool     `long:"without-partition-range" description:"Without the specific code of PARTITION BY RANGE"`
 		Help                  bool     `long:"help" description:"Show this help"`
 		Version               bool     `long:"version" description:"Show this version"`
 	}
@@ -55,11 +56,12 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
 	options := sqldef.Options{
-		DesiredFile: desiredFile,
-		CurrentFile: currentFile,
-		DryRun:      opts.DryRun,
-		Export:      opts.Export,
-		SkipDrop:    opts.SkipDrop,
+		DesiredFile:           desiredFile,
+		CurrentFile:           currentFile,
+		DryRun:                opts.DryRun,
+		Export:                opts.Export,
+		SkipDrop:              opts.SkipDrop,
+		WithoutPartitionRange: opts.WithoutPartitionRange,
 	}
 
 	database := ""

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -34,6 +34,8 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		SkipDrop              bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
 		WithoutPartitionRange bool     `long:"without-partition-range" description:"Without the specific code of PARTITION BY RANGE"`
 		InitAutoIncrement     bool     `long:"init-auto-increment" description:"Initialize AUTO_INCREMENT for CREATE TABLE"`
+		Targets               string   `long:"targets" description:"Manage the target name (Table, View, Type, Trigger)"`
+		TargetFile            string   `long:"target-file" description:"File management of --targets option"`
 		Help                  bool     `long:"help" description:"Show this help"`
 		Version               bool     `long:"version" description:"Show this version"`
 	}
@@ -56,6 +58,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+	targets := sqldef.MargeTargets(opts.Targets, opts.TargetFile)
 	options := sqldef.Options{
 		DesiredFile:           desiredFile,
 		CurrentFile:           currentFile,
@@ -64,6 +67,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		SkipDrop:              opts.SkipDrop,
 		WithoutPartitionRange: opts.WithoutPartitionRange,
 		InitAutoIncrement:     opts.InitAutoIncrement,
+		Targets:               targets,
 	}
 
 	database := ""

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -1355,10 +1355,10 @@ func TestMysqldefExportWithoutPartitionRange(t *testing.T) {
 
 	createTable := "CREATE TABLE `users` (\n" +
 		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
-		"  `name` varchar(255) DEFAULT NULL,\n" +
+		"  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,\n" +
 		"  `account_id` bigint DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`)\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
 	partitions := "/*!50100 PARTITION BY RANGE (`id`)\n" +
 		"(PARTITION p0 VALUES LESS THAN (5) ENGINE = InnoDB,\n" +
 		" PARTITION p1 VALUES LESS THAN (10) ENGINE = InnoDB,\n" +
@@ -1383,10 +1383,10 @@ func TestMysqldefWithoutPartitionRange(t *testing.T) {
 
 	createTable := "CREATE TABLE `users` (\n" +
 		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
-		"  `name` varchar(255) DEFAULT NULL,\n" +
+		"  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,\n" +
 		"  `account_id` bigint DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`)\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
 	partitions := "/*!50100 PARTITION BY RANGE (`id`)\n" +
 		"(PARTITION p0 VALUES LESS THAN (5) ENGINE = InnoDB,\n" +
 		" PARTITION p1 VALUES LESS THAN (10) ENGINE = InnoDB,\n" +
@@ -1407,10 +1407,10 @@ func TestMysqldefExportInitAutoIncrement(t *testing.T) {
 	autoIncrement := "AUTO_INCREMENT=123 "
 	createTable := "CREATE TABLE `users` (\n" +
 		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
-		"  `name` varchar(255) DEFAULT NULL,\n" +
+		"  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,\n" +
 		"  `account_id` bigint DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`)\n" +
-		") ENGINE=InnoDB %sDEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;\n"
+		") ENGINE=InnoDB %sDEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n"
 
 	createTableDDL := fmt.Sprintf(createTable, autoIncrement)
 	createTableWithoutAutoIncrementDDL := fmt.Sprintf(createTable, "")
@@ -1429,10 +1429,10 @@ func TestMysqldefInitAutoIncrement(t *testing.T) {
 	autoIncrement := "AUTO_INCREMENT=123 "
 	createTable := "CREATE TABLE `users` (\n" +
 		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
-		"  `name` varchar(255) DEFAULT NULL,\n" +
+		"  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,\n" +
 		"  `account_id` bigint DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`)\n" +
-		") ENGINE=InnoDB %sDEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;\n"
+		") ENGINE=InnoDB %sDEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n"
 
 	createTableDDL := fmt.Sprintf(createTable, autoIncrement)
 	createTableWithoutAutoIncrementDDL := fmt.Sprintf(createTable, "")
@@ -1447,7 +1447,7 @@ func TestMysqldefExportLimitedTargets(t *testing.T) {
 
 	createTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;\n"
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n"
 	for i := 1; i <= 3; i++ {
 		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(createTable, i))
 	}
@@ -1460,11 +1460,11 @@ func TestMysqldefLimitedTargets(t *testing.T) {
 
 	createTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
 	modifiedCreateTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL,\n" +
-		"  `name` varchar(40) DEFAULT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+		"  `name` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
 
 	// Prepare the modified schema.sql
 	resetTestDatabase()
@@ -1483,7 +1483,7 @@ func TestMysqldefLimitedTargets(t *testing.T) {
 	apply := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--targets", "users1,users3,users7", "--file", "schema.sql")
 	assertEquals(t, apply,
 		applyPrefix+
-			"ALTER TABLE `users3` ADD COLUMN `name` varchar(40) DEFAULT null AFTER `id`;\n"+
+			"ALTER TABLE `users3` ADD COLUMN `name` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT null AFTER `id`;\n"+
 			fmt.Sprintf(modifiedCreateTable, 7)+"\n"+
 			"DROP TABLE `users1`;\n")
 }
@@ -1493,7 +1493,7 @@ func TestMysqldefExportTargetFile(t *testing.T) {
 
 	createTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;\n"
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n"
 	for i := 1; i <= 5; i++ {
 		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(createTable, i))
 	}
@@ -1507,11 +1507,11 @@ func TestMysqldefTargetFile(t *testing.T) {
 
 	createTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
 	modifiedCreateTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL,\n" +
-		"  `name` varchar(40) DEFAULT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;"
+		"  `name` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
 
 	// Prepare the modified schema.sql
 	resetTestDatabase()
@@ -1532,7 +1532,7 @@ func TestMysqldefTargetFile(t *testing.T) {
 	apply := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--target-file", "target-list", "--file", "schema.sql")
 	assertEquals(t, apply,
 		applyPrefix+
-			"ALTER TABLE `users4` ADD COLUMN `name` varchar(40) DEFAULT null AFTER `id`;\n"+
+			"ALTER TABLE `users4` ADD COLUMN `name` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT null AFTER `id`;\n"+
 			fmt.Sprintf(modifiedCreateTable, 6)+"\n"+
 			"DROP TABLE `users2`;\n")
 }

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -1355,10 +1355,10 @@ func TestMysqldefExportWithoutPartitionRange(t *testing.T) {
 
 	createTable := "CREATE TABLE `users` (\n" +
 		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
-		"  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,\n" +
+		"  `name` varchar(255) DEFAULT NULL,\n" +
 		"  `account_id` bigint DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`)\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1"
 	partitions := "/*!50100 PARTITION BY RANGE (`id`)\n" +
 		"(PARTITION p0 VALUES LESS THAN (5) ENGINE = InnoDB,\n" +
 		" PARTITION p1 VALUES LESS THAN (10) ENGINE = InnoDB,\n" +
@@ -1383,10 +1383,10 @@ func TestMysqldefWithoutPartitionRange(t *testing.T) {
 
 	createTable := "CREATE TABLE `users` (\n" +
 		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
-		"  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,\n" +
+		"  `name` varchar(255) DEFAULT NULL,\n" +
 		"  `account_id` bigint DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`)\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1"
 	partitions := "/*!50100 PARTITION BY RANGE (`id`)\n" +
 		"(PARTITION p0 VALUES LESS THAN (5) ENGINE = InnoDB,\n" +
 		" PARTITION p1 VALUES LESS THAN (10) ENGINE = InnoDB,\n" +
@@ -1407,10 +1407,10 @@ func TestMysqldefExportInitAutoIncrement(t *testing.T) {
 	autoIncrement := "AUTO_INCREMENT=123 "
 	createTable := "CREATE TABLE `users` (\n" +
 		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
-		"  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,\n" +
+		"  `name` varchar(255) DEFAULT NULL,\n" +
 		"  `account_id` bigint DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`)\n" +
-		") ENGINE=InnoDB %sDEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n"
+		") ENGINE=InnoDB %sDEFAULT CHARSET=latin1;\n"
 
 	createTableDDL := fmt.Sprintf(createTable, autoIncrement)
 	createTableWithoutAutoIncrementDDL := fmt.Sprintf(createTable, "")
@@ -1429,10 +1429,10 @@ func TestMysqldefInitAutoIncrement(t *testing.T) {
 	autoIncrement := "AUTO_INCREMENT=123 "
 	createTable := "CREATE TABLE `users` (\n" +
 		"  `id` bigint NOT NULL AUTO_INCREMENT,\n" +
-		"  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,\n" +
+		"  `name` varchar(255) DEFAULT NULL,\n" +
 		"  `account_id` bigint DEFAULT NULL,\n" +
 		"  PRIMARY KEY (`id`)\n" +
-		") ENGINE=InnoDB %sDEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n"
+		") ENGINE=InnoDB %sDEFAULT CHARSET=latin1;\n"
 
 	createTableDDL := fmt.Sprintf(createTable, autoIncrement)
 	createTableWithoutAutoIncrementDDL := fmt.Sprintf(createTable, "")
@@ -1447,7 +1447,7 @@ func TestMysqldefExportLimitedTargets(t *testing.T) {
 
 	createTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n"
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;\n"
 	for i := 1; i <= 3; i++ {
 		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(createTable, i))
 	}
@@ -1460,11 +1460,11 @@ func TestMysqldefLimitedTargets(t *testing.T) {
 
 	createTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;"
 	modifiedCreateTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL,\n" +
-		"  `name` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
+		"  `name` varchar(40) DEFAULT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;"
 
 	// Prepare the modified schema.sql
 	resetTestDatabase()
@@ -1483,7 +1483,7 @@ func TestMysqldefLimitedTargets(t *testing.T) {
 	apply := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--targets", "users1,users3,users7", "--file", "schema.sql")
 	assertEquals(t, apply,
 		applyPrefix+
-			"ALTER TABLE `users3` ADD COLUMN `name` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT null AFTER `id`;\n"+
+			"ALTER TABLE `users3` ADD COLUMN `name` varchar(40) DEFAULT null AFTER `id`;\n"+
 			fmt.Sprintf(modifiedCreateTable, 7)+"\n"+
 			"DROP TABLE `users1`;\n")
 }
@@ -1493,7 +1493,7 @@ func TestMysqldefExportTargetFile(t *testing.T) {
 
 	createTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;\n"
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;\n"
 	for i := 1; i <= 5; i++ {
 		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(createTable, i))
 	}
@@ -1507,11 +1507,11 @@ func TestMysqldefTargetFile(t *testing.T) {
 
 	createTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;"
 	modifiedCreateTable := "CREATE TABLE `users%d` (\n" +
 		"  `id` bigint NOT NULL,\n" +
-		"  `name` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;"
+		"  `name` varchar(40) DEFAULT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;"
 
 	// Prepare the modified schema.sql
 	resetTestDatabase()
@@ -1532,7 +1532,7 @@ func TestMysqldefTargetFile(t *testing.T) {
 	apply := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--target-file", "target-list", "--file", "schema.sql")
 	assertEquals(t, apply,
 		applyPrefix+
-			"ALTER TABLE `users4` ADD COLUMN `name` varchar(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT null AFTER `id`;\n"+
+			"ALTER TABLE `users4` ADD COLUMN `name` varchar(40) DEFAULT null AFTER `id`;\n"+
 			fmt.Sprintf(modifiedCreateTable, 6)+"\n"+
 			"DROP TABLE `users2`;\n")
 }

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -6,11 +6,10 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/k0kubun/sqldef/adapter/file"
-
 	"github.com/jessevdk/go-flags"
 	"github.com/k0kubun/sqldef"
 	"github.com/k0kubun/sqldef/adapter"
+	"github.com/k0kubun/sqldef/adapter/file"
 	"github.com/k0kubun/sqldef/adapter/postgres"
 	"github.com/k0kubun/sqldef/schema"
 	"golang.org/x/term"
@@ -32,6 +31,8 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		Export      bool     `long:"export" description:"Just dump the current schema to stdout"`
 		SkipDrop    bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
 		BeforeApply string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
+		Targets     string   `long:"targets" description:"Manage the target name (Table, View, Type, Trigger)"`
+		TargetFile  string   `long:"target-file" description:"File management of --targets option"`
 		Help        bool     `long:"help" description:"Show this help"`
 		Version     bool     `long:"version" description:"Show this version"`
 	}
@@ -54,6 +55,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+	targets := sqldef.MargeTargets(opts.Targets, opts.TargetFile)
 	options := sqldef.Options{
 		DesiredFile: desiredFile,
 		CurrentFile: currentFile,
@@ -61,6 +63,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		Export:      opts.Export,
 		SkipDrop:    opts.SkipDrop,
 		BeforeApply: opts.BeforeApply,
+		Targets:     targets,
 	}
 
 	database := ""

--- a/cmd/sqlite3def/sqlite3def.go
+++ b/cmd/sqlite3def/sqlite3def.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/k0kubun/sqldef/adapter/file"
 	"log"
 	"os"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/k0kubun/sqldef"
 	"github.com/k0kubun/sqldef/adapter"
+	"github.com/k0kubun/sqldef/adapter/file"
 	"github.com/k0kubun/sqldef/adapter/sqlite3"
 	"github.com/k0kubun/sqldef/schema"
 )
@@ -19,12 +19,14 @@ var version string
 // TODO: Support `sqldef schema.sql -opt val...`
 func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	var opts struct {
-		File     []string `short:"f" long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"filename" default:"-"`
-		DryRun   bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
-		Export   bool     `long:"export" description:"Just dump the current schema to stdout"`
-		SkipDrop bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
-		Help     bool     `long:"help" description:"Show this help"`
-		Version  bool     `long:"version" description:"Show this version"`
+		File       []string `short:"f" long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"filename" default:"-"`
+		DryRun     bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Export     bool     `long:"export" description:"Just dump the current schema to stdout"`
+		SkipDrop   bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
+		Targets    string   `long:"targets" description:"Manage the target name (Table, View, Type, Trigger)"`
+		TargetFile string   `long:"target-file" description:"File management of --targets option"`
+		Help       bool     `long:"help" description:"Show this help"`
+		Version    bool     `long:"version" description:"Show this version"`
 	}
 
 	parser := flags.NewParser(&opts, flags.None)
@@ -45,12 +47,14 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+	targets := sqldef.MargeTargets(opts.Targets, opts.TargetFile)
 	options := sqldef.Options{
 		DesiredFile: desiredFile,
 		CurrentFile: currentFile,
 		DryRun:      opts.DryRun,
 		Export:      opts.Export,
 		SkipDrop:    opts.SkipDrop,
+		Targets:     targets,
 	}
 
 	database := ""

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -1,6 +1,7 @@
 package schema
 
 type DDL interface {
+	Name() string
 	Statement() string
 }
 
@@ -262,6 +263,42 @@ func (t *Trigger) Statement() string {
 
 func (t *Type) Statement() string {
 	return t.statement
+}
+
+func (c *CreateTable) Name() string {
+	return c.table.name
+}
+
+func (c *CreateIndex) Name() string {
+	return c.tableName
+}
+
+func (a *AddIndex) Name() string {
+	return a.tableName
+}
+
+func (a *AddPrimaryKey) Name() string {
+	return a.tableName
+}
+
+func (a *AddForeignKey) Name() string {
+	return a.tableName
+}
+
+func (a *AddPolicy) Name() string {
+	return a.tableName
+}
+
+func (v *View) Name() string {
+	return v.name
+}
+
+func (t *Trigger) Name() string {
+	return t.tableName
+}
+
+func (t *Type) Name() string {
+	return t.name
 }
 
 func (t *Table) PrimaryKey() *Index {

--- a/sqldef.go
+++ b/sqldef.go
@@ -21,6 +21,7 @@ type Options struct {
 	BeforeApply           string
 	WithoutPartitionRange bool
 	InitAutoIncrement     bool
+	Targets               []string
 }
 
 // Main function shared by `mysqldef` and `psqldef`
@@ -30,6 +31,7 @@ func Run(generatorMode schema.GeneratorMode, db adapter.Database, options *Optio
 		log.Fatal(fmt.Sprintf("Error on DumpDDLs: %s", err))
 	}
 	currentDDLs = filterDDLs(currentDDLs, options)
+	currentDDLs = filterTargets(generatorMode, currentDDLs, options.Targets)
 
 	if options.Export {
 		if currentDDLs == "" {
@@ -46,7 +48,7 @@ func Run(generatorMode schema.GeneratorMode, db adapter.Database, options *Optio
 	}
 	desiredDDLs := filterDDLs(sql, options)
 
-	ddls, err := schema.GenerateIdempotentDDLs(generatorMode, desiredDDLs, currentDDLs)
+	ddls, err := schema.GenerateIdempotentTargetedDDLs(generatorMode, desiredDDLs, currentDDLs, options.Targets)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -140,4 +142,52 @@ func filterPartitionRange(sql string) string {
 // Initialize count of environment-dependent `AUTO_INCREMENT`
 func initAutoIncrement(sql string) string {
 	return regexp.MustCompile(`AUTO_INCREMENT=[0-9]* `).ReplaceAllString(sql, "")
+}
+
+func filterTargets(mode schema.GeneratorMode, currentDDLs string, targets []string) string {
+
+	if len(targets) <= 0 {
+		return currentDDLs
+	}
+
+	ddls, err := schema.ParseDDLs(mode, currentDDLs)
+	if err != nil {
+		return currentDDLs
+	}
+
+	filtered := []string{}
+	for _, ddl := range ddls {
+		if containsString(targets, ddl.Name()) {
+			filtered = append(filtered, ddl.Statement()+";")
+		}
+	}
+
+	return strings.Join(filtered, "\n\n")
+}
+
+func containsString(strs []string, str string) bool {
+	for _, s := range strs {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}
+
+func MargeTargets(targets string, targetFile string) []string {
+	result := []string{}
+
+	t1 := strings.Split(strings.TrimSpace(targets), ",")
+	if len(t1) <= 0 || t1[0] != "" {
+		result = append(result, t1...)
+	}
+
+	if raw, err := ReadFile(targetFile); err == nil {
+		t2 := strings.Split(strings.Trim(strings.TrimSpace(raw), "\n"), "\n")
+		if len(t2) <= 0 || t2[0] != "" {
+			result = append(result, t2...)
+		}
+	}
+
+	return result
 }

--- a/sqldef.go
+++ b/sqldef.go
@@ -20,6 +20,7 @@ type Options struct {
 	SkipDrop              bool
 	BeforeApply           string
 	WithoutPartitionRange bool
+	InitAutoIncrement     bool
 }
 
 // Main function shared by `mysqldef` and `psqldef`
@@ -123,6 +124,9 @@ func filterDDLs(sql string, options *Options) string {
 	if options.WithoutPartitionRange {
 		sql = filterPartitionRange(sql)
 	}
+	if options.InitAutoIncrement {
+		sql = initAutoIncrement(sql)
+	}
 	return sql
 }
 
@@ -130,4 +134,10 @@ func filterDDLs(sql string, options *Options) string {
 // Filter specific code for environment-dependent `PARTITION BY RANGE`
 func filterPartitionRange(sql string) string {
 	return regexp.MustCompile(`\n\/\*![0-9]* PARTITION BY RANGE[\s\S]*?\*\/`).ReplaceAllString(sql, "")
+}
+
+// For MySQL
+// Initialize count of environment-dependent `AUTO_INCREMENT`
+func initAutoIncrement(sql string) string {
+	return regexp.MustCompile(`AUTO_INCREMENT=[0-9]* `).ReplaceAllString(sql, "")
 }


### PR DESCRIPTION
I have added 3 features to avoid environment dependence.
It would be useful to use sqldef across environments. (e.g. local/dev/stg/prod)

# --targets, --target-file  (For All)
```
--targets                     Manage the target name (Table, View, Type, Trigger)
--target-file                 File management of --targets option
```
This feature can be manage target tables.
Managing with files makes it easier to manage tables.
For example, if there are tables such as `users_backup` or `items_20220301` only in production, you can ignore them.
See `README.md` for a sample.

Review Tips => commit: b627290807dfdeb4bb7ce84881860103eb57a736

# --without-partition-range (For MySQL)
```
--without-partition-range     Without the specific code of PARTITION BY RANGE
```
In MySQL, partition information exists in DumpDDL.
Currently, its presence causes a syntax error, which can be avoided by this feature.
For example, if manage partitions by date and there are differences in the environment, it can be ignore them.
See `README.md` for a sample.

Review Tips => commit: 1fe7e3f6d5096d05fd62b57165a016a248e3aebd

# --init-auto-increment   (For MySQL)
```
--init-auto-increment         Initialize AUTO_INCREMENT for CREATE TABLE
```
MySQL has an `AUTO_INCREMENT` count in DumpDDL.
We want to clear this count when we execute `CREATE TABLE` across environments. This feature does that.
See `README.md` for a sample.

Review Tips => commit: e9b5868501b8ffe940a27810527cd9932e7a8482