### PR TITLE
feat: [mysqldef] avoid environment-dependent for PARTITION BY RANGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Application Options:
       --dry-run                     Don't run DDLs but just show them
       --export                      Just dump the current schema to stdout
       --skip-drop                   Skip destructive changes such as DROP
+      --targets                     Manage the target name (Table, View, Type, Trigger)
+      --target-file                 File management of --targets option
       --help                        Show this help
       --version                     Show this version
 ```
@@ -98,6 +100,33 @@ $ mysqldef -uroot test --skip-drop < schema.sql
 Skipped: 'DROP TABLE users;'
 ```
 
+#### Options to avoid environment dependence
+
+These options may be useful when running in different environments (e.g. stg <->prod)
+
+##### --targets, --target-file
+
+Tables other than users, orders, mails are ignored
+
+```sql
+$ mysqldef -uroot test --targets users,orders,mails --export > schema.sql
+$ mysqldef -uroot test --targets users,orders,mails < schema.sql
+```
+
+The following works the same as the command above
+
+```plaintext
+# Save as file with the name `tables_file`
+users
+orders
+mails
+```
+
+```sql
+$ mysqldef -uroot test --target-file tables_file --export > schema.sql
+$ mysqldef -uroot test --target-file tables_file < schema.sql
+```
+
 ### psqldef
 
 `psqldef` should work in the same way as `psql` for setting connection information.
@@ -117,6 +146,8 @@ Application Options:
       --dry-run              Don't run DDLs but just show them
       --export               Just dump the current schema to stdout
       --skip-drop            Skip destructive changes such as DROP
+      --targets              Manage the target name (Table, View, Type, Trigger)
+      --target-file          File management of --targets option
       --help                 Show this help
 ```
 
@@ -197,6 +228,8 @@ Application Options:
       --dry-run          Don't run DDLs but just show them
       --export           Just dump the current schema to stdout
       --skip-drop        Skip destructive changes such as DROP
+      --targets          Manage the target name (Table, View, Type, Trigger)
+      --target-file      File management of --targets option
       --help             Show this help
 ```
 
@@ -216,6 +249,8 @@ Application Options:
       --dry-run              Don't run DDLs but just show them
       --export               Just dump the current schema to stdout
       --skip-drop            Skip destructive changes such as DROP
+      --targets              Manage the target name (Table, View, Type, Trigger)
+      --target-file          File management of --targets option
       --help                 Show this help
       --version              Show this version
 ```

--- a/README.md
+++ b/README.md
@@ -142,14 +142,6 @@ CREATE TABLE user (
 ```
 
 ```sql
-$ mysqldef -uroot test --export --ignore-partition-range > schema.sql
-CREATE TABLE user (
-  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  name VARCHAR(128) DEFAULT 'user1',
-) Engine=InnoDB DEFAULT CHARSET=utf8mb4;
-```
-
-```sql
 $ mysqldef -uroot test --export > schema.sql
 $ mysqldef -uroot test --dry-run --ignore-partition-range < schema.sql
 Run: 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Application Options:
       --dry-run                     Don't run DDLs but just show them
       --export                      Just dump the current schema to stdout
       --skip-drop                   Skip destructive changes such as DROP
-      --without-partition-range     Without the specific code of PARTITION BY RANGE
+      --ignore-partition-range      Ignore the specific code of PARTITION BY RANGE
       --targets                     Manage the target name (Table, View, Type, Trigger)
       --target-file                 File management of --targets option
       --help                        Show this help

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Application Options:
       --dry-run                     Don't run DDLs but just show them
       --export                      Just dump the current schema to stdout
       --skip-drop                   Skip destructive changes such as DROP
+      --without-partition-range     Without the specific code of PARTITION BY RANGE
       --targets                     Manage the target name (Table, View, Type, Trigger)
       --target-file                 File management of --targets option
       --help                        Show this help
@@ -125,6 +126,37 @@ mails
 ```sql
 $ mysqldef -uroot test --target-file tables_file --export > schema.sql
 $ mysqldef -uroot test --target-file tables_file < schema.sql
+```
+
+##### --ignore-partition-range
+```sql
+# original schema
+CREATE TABLE user (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(128) DEFAULT 'user1',
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4
+/*!50100 PARTITION BY RANGE (`id`)
+(PARTITION p0 VALUES LESS THAN (5) ENGINE = InnoDB,
+ PARTITION p1 VALUES LESS THAN (10) ENGINE = InnoDB,
+ PARTITION p2 VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */;
+```
+
+```sql
+$ mysqldef -uroot test --export --ignore-partition-range > schema.sql
+CREATE TABLE user (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(128) DEFAULT 'user1',
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+```sql
+$ mysqldef -uroot test --export > schema.sql
+$ mysqldef -uroot test --dry-run --ignore-partition-range < schema.sql
+Run: 
+CREATE TABLE user (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(128) DEFAULT 'user1',
+) Engine=InnoDB DEFAULT CHARSET=utf8mb4;
 ```
 
 ### psqldef

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -35,6 +35,8 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		SkipDrop              bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
 		SkipView              bool     `long:"skip-view" description:"Skip managing views (temporary feature, to be removed later)"`
 		BeforeApply           string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
+		Targets               string   `long:"targets" description:"Manage the target name (Table, View, Type, Trigger)"`
+		TargetFile            string   `long:"target-file" description:"File management of --targets option"`
 		Help                  bool     `long:"help" description:"Show this help"`
 		Version               bool     `long:"version" description:"Show this version"`
 	}
@@ -57,6 +59,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+	targets := sqldef.MargeTargets(opts.Targets, opts.TargetFile)
 	options := sqldef.Options{
 		DesiredFile: desiredFile,
 		CurrentFile: currentFile,
@@ -64,6 +67,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		Export:      opts.Export,
 		SkipDrop:    opts.SkipDrop,
 		BeforeApply: opts.BeforeApply,
+		Targets:     targets,
 	}
 
 	database := ""

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -35,6 +35,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		SkipDrop              bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
 		SkipView              bool     `long:"skip-view" description:"Skip managing views (temporary feature, to be removed later)"`
 		BeforeApply           string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
+		IgnorePartitionRange  bool     `long:"ignore-partition-range" description:"Ignore the specific code of PARTITION BY RANGE"`
 		Targets               string   `long:"targets" description:"Manage the target name (Table, View, Type, Trigger)"`
 		TargetFile            string   `long:"target-file" description:"File management of --targets option"`
 		Help                  bool     `long:"help" description:"Show this help"`
@@ -61,13 +62,14 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
 	targets := sqldef.MargeTargets(opts.Targets, opts.TargetFile)
 	options := sqldef.Options{
-		DesiredFile: desiredFile,
-		CurrentFile: currentFile,
-		DryRun:      opts.DryRun,
-		Export:      opts.Export,
-		SkipDrop:    opts.SkipDrop,
-		BeforeApply: opts.BeforeApply,
-		Targets:     targets,
+		DesiredFile:          desiredFile,
+		CurrentFile:          currentFile,
+		DryRun:               opts.DryRun,
+		Export:               opts.Export,
+		SkipDrop:             opts.SkipDrop,
+		BeforeApply:          opts.BeforeApply,
+		IgnorePartitionRange: opts.IgnorePartitionRange,
+		Targets:              targets,
 	}
 
 	database := ""

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -1388,6 +1388,57 @@ func TestMysqldefBeforeApply(t *testing.T) {
 	assertEquals(t, apply, nothingModified)
 }
 
+func TestMysqldefExportIgnorePartitionRange(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := "CREATE TABLE `users` (\n" +
+		"  `uuid` varchar(37) NOT NULL,\n" +
+		"  `name` varchar(255) DEFAULT NULL,\n" +
+		"  `joined` date NOT NULL,\n" +
+		"  PRIMARY KEY (`uuid`,`joined`)\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1"
+	partitions := "/*!50100 PARTITION BY RANGE (year(`joined`))\n" +
+		"(PARTITION p0 VALUES LESS THAN (1960) ENGINE = InnoDB,\n" +
+		" PARTITION p1 VALUES LESS THAN (1970) ENGINE = InnoDB,\n" +
+		" PARTITION p2 VALUES LESS THAN (1980) ENGINE = InnoDB,\n" +
+		" PARTITION p3 VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */"
+
+	createTableDDL := createTable + ";\n"
+	createTableWithPartitionDDL := createTable + "\n" + partitions + ";\n"
+	mustExecute("mysql", "-uroot", "mysqldef_test", "-e", stripHeredoc(createTableWithPartitionDDL))
+
+	writeFile("schema.sql", "")
+
+	out := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--export", "--file", "schema.sql")
+	assertEquals(t, out, createTableWithPartitionDDL)
+
+	out = assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--ignore-partition-range", "--export", "--file", "schema.sql")
+	assertEquals(t, out, createTableDDL)
+}
+
+func TestMysqldefIgnorePartitionRange(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := "CREATE TABLE `users` (\n" +
+		"  `uuid` varchar(37) NOT NULL,\n" +
+		"  `name` varchar(255) DEFAULT NULL,\n" +
+		"  `joined` date NOT NULL,\n" +
+		"  PRIMARY KEY (`uuid`,`joined`)\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1"
+	partitions := "/*!50100 PARTITION BY RANGE (year(`joined`))\n" +
+		"(PARTITION p0 VALUES LESS THAN (1960) ENGINE = InnoDB,\n" +
+		" PARTITION p1 VALUES LESS THAN (1970) ENGINE = InnoDB,\n" +
+		" PARTITION p2 VALUES LESS THAN (1980) ENGINE = InnoDB,\n" +
+		" PARTITION p3 VALUES LESS THAN MAXVALUE ENGINE = InnoDB) */"
+
+	createTableDDL := createTable + ";\n"
+	createTableWithPartitionDDL := createTable + "\n" + partitions + ";\n"
+	writeFile("schema.sql", createTableWithPartitionDDL)
+
+	apply := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--ignore-partition-range", "--file", "schema.sql")
+	assertEquals(t, apply, applyPrefix+createTableDDL)
+}
+
 func TestMysqldefExportLimitedTargets(t *testing.T) {
 	resetTestDatabase()
 

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -1387,6 +1388,101 @@ func TestMysqldefBeforeApply(t *testing.T) {
 	assertEquals(t, apply, nothingModified)
 }
 
+func TestMysqldefExportLimitedTargets(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := "CREATE TABLE `users%d` (\n" +
+		"  `uuid` varchar(37) NOT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;\n"
+	for i := 1; i <= 3; i++ {
+		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(createTable, i))
+	}
+
+	out := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--export", "--targets", "users1,users3")
+	assertEquals(t, out, fmt.Sprintf(createTable, 1)+"\n"+fmt.Sprintf(createTable, 3))
+}
+
+func TestMysqldefLimitedTargets(t *testing.T) {
+
+	createTable := "CREATE TABLE `users%d` (\n" +
+		"  `uuid` varchar(37) NOT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;"
+	modifiedCreateTable := "CREATE TABLE `users%d` (\n" +
+		"  `uuid` varchar(37) NOT NULL,\n" +
+		"  `name` varchar(40) DEFAULT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;"
+
+	// Prepare the modified schema.sql
+	resetTestDatabase()
+	for i := 3; i <= 7; i++ {
+		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(modifiedCreateTable, i))
+	}
+	out := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--export", "--file", "schema.sql")
+	writeFile("schema.sql", out)
+
+	// Run test
+	resetTestDatabase()
+	for i := 1; i <= 5; i++ {
+		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(createTable, i))
+	}
+
+	apply := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--targets", "users1,users3,users7", "--file", "schema.sql")
+	assertEquals(t, apply,
+		applyPrefix+
+			"ALTER TABLE `users3` ADD COLUMN `name` varchar(40) DEFAULT null AFTER `uuid`;\n"+
+			fmt.Sprintf(modifiedCreateTable, 7)+"\n"+
+			"DROP TABLE `users1`;\n")
+}
+
+func TestMysqldefExportTargetFile(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := "CREATE TABLE `users%d` (\n" +
+		"  `uuid` varchar(37) NOT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;\n"
+	for i := 1; i <= 5; i++ {
+		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(createTable, i))
+	}
+	writeFile("target-list", "users2\nusers4\nusers5")
+
+	out := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--export", "--target-file", "target-list")
+	assertEquals(t, out, fmt.Sprintf(createTable, 2)+"\n"+fmt.Sprintf(createTable, 4)+"\n"+fmt.Sprintf(createTable, 5))
+}
+
+func TestMysqldefTargetFile(t *testing.T) {
+
+	createTable := "CREATE TABLE `users%d` (\n" +
+		"  `uuid` varchar(37) NOT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;"
+	modifiedCreateTable := "CREATE TABLE `users%d` (\n" +
+		"  `uuid` varchar(37) NOT NULL,\n" +
+		"  `name` varchar(40) DEFAULT NULL\n" +
+		") ENGINE=InnoDB DEFAULT CHARSET=latin1;"
+
+	// Prepare the modified schema.sql
+	resetTestDatabase()
+	for i := 3; i <= 7; i++ {
+		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(modifiedCreateTable, i))
+	}
+	out := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--export", "--file", "schema.sql")
+	writeFile("schema.sql", out)
+
+	// Run test
+	resetTestDatabase()
+	for i := 1; i <= 5; i++ {
+		mustExecute("mysql", "-uroot", "mysqldef_test", "-e", fmt.Sprintf(createTable, i))
+	}
+
+	writeFile("target-list", "users2\nusers4\nusers6")
+
+	apply := assertedExecute(t, "./mysqldef", "-uroot", "mysqldef_test", "--target-file", "target-list", "--file", "schema.sql")
+	assertEquals(t, apply,
+		applyPrefix+
+			"ALTER TABLE `users4` ADD COLUMN `name` varchar(40) DEFAULT null AFTER `uuid`;\n"+
+			fmt.Sprintf(modifiedCreateTable, 6)+"\n"+
+			"DROP TABLE `users2`;\n")
+}
+
 func TestMysqldefHelp(t *testing.T) {
 	_, err := execute("./mysqldef", "--help")
 	if err != nil {
@@ -1409,6 +1505,7 @@ func TestMain(m *testing.M) {
 	status := m.Run()
 	_ = os.Remove("mysqldef")
 	_ = os.Remove("schema.sql")
+	_ = os.Remove("target-list")
 	os.Exit(status)
 }
 

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -7,11 +7,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/k0kubun/sqldef/adapter/file"
-
 	"github.com/jessevdk/go-flags"
 	"github.com/k0kubun/sqldef"
 	"github.com/k0kubun/sqldef/adapter"
+	"github.com/k0kubun/sqldef/adapter/file"
 	"github.com/k0kubun/sqldef/adapter/postgres"
 	"github.com/k0kubun/sqldef/schema"
 	"golang.org/x/term"
@@ -33,6 +32,8 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		Export      bool     `long:"export" description:"Just dump the current schema to stdout"`
 		SkipDrop    bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
 		BeforeApply string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
+		Targets     string   `long:"targets" description:"Manage the target name (Table, View, Type, Trigger)"`
+		TargetFile  string   `long:"target-file" description:"File management of --targets option"`
 		Help        bool     `long:"help" description:"Show this help"`
 		Version     bool     `long:"version" description:"Show this version"`
 	}
@@ -55,6 +56,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+	targets := sqldef.MargeTargets(opts.Targets, opts.TargetFile)
 	options := sqldef.Options{
 		DesiredFile: desiredFile,
 		CurrentFile: currentFile,
@@ -62,6 +64,7 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 		Export:      opts.Export,
 		SkipDrop:    opts.SkipDrop,
 		BeforeApply: opts.BeforeApply,
+		Targets:     targets,
 	}
 
 	database := ""

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -7,16 +7,17 @@ package main
 
 import (
 	"fmt"
-	"github.com/k0kubun/sqldef/adapter"
-	"github.com/k0kubun/sqldef/adapter/postgres"
-	"github.com/k0kubun/sqldef/cmd/testutils"
-	"github.com/k0kubun/sqldef/schema"
 	"log"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/k0kubun/sqldef/adapter"
+	"github.com/k0kubun/sqldef/adapter/postgres"
+	"github.com/k0kubun/sqldef/cmd/testutils"
+	"github.com/k0kubun/sqldef/schema"
 )
 
 const (
@@ -1362,6 +1363,110 @@ func TestPsqldefBeforeApply(t *testing.T) {
 	assertEquals(t, owner, "dummy_owner_role\n")
 }
 
+func TestPsqldefExportLimitedTargets(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := stripHeredoc(
+		`CREATE TABLE public.users%d (
+		    "id" bigint NOT NULL
+		);
+		`)
+	for i := 1; i <= 3; i++ {
+		mustExecute("psql", "-Upostgres", database, "-tAc", fmt.Sprintf(createTable, i))
+	}
+
+	out := assertedExecute(t, "./psqldef", "-Upostgres", database, "--export", "--targets", "public.users1,public.users3")
+	assertEquals(t, out, fmt.Sprintf(createTable, 1)+"\n"+fmt.Sprintf(createTable, 3))
+}
+
+func TestPsqldefLimitedTargets(t *testing.T) {
+
+	createTable := stripHeredoc(
+		`CREATE TABLE public.users%d (
+		    "id" bigint NOT NULL
+		);`)
+	modifiedCreateTable := stripHeredoc(
+		`CREATE TABLE public.users%d (
+		    "id" bigint NOT NULL,
+		    "name" character varying(30)
+		);`)
+
+	// Prepare the modified schema.sql
+	resetTestDatabase()
+	for i := 3; i <= 7; i++ {
+		mustExecute("psql", "-Upostgres", database, "-tAc", fmt.Sprintf(modifiedCreateTable, i))
+	}
+	out := assertedExecute(t, "./psqldef", "-Upostgres", database, "--export", "--file", "schema.sql")
+	writeFile("schema.sql", out)
+
+	// Run test
+	resetTestDatabase()
+	for i := 1; i <= 5; i++ {
+		mustExecute("psql", "-Upostgres", database, "-tAc", fmt.Sprintf(createTable, i))
+	}
+
+	apply := assertedExecute(t, "./psqldef", "-Upostgres", database, "--targets", "public.users1,public.users3,public.users7", "--file", "schema.sql")
+	assertEquals(t, apply,
+		applyPrefix+
+			`ALTER TABLE "public"."users3" ADD COLUMN "name" character varying(30);`+"\n"+
+			fmt.Sprintf(modifiedCreateTable, 7)+"\n"+
+			`DROP TABLE "public"."users1";`+"\n")
+}
+
+func TestPsqldefExportTargetFile(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := stripHeredoc(
+		`CREATE TABLE public.users%d (
+		    "id" bigint NOT NULL
+		);
+		`)
+	for i := 1; i <= 5; i++ {
+		mustExecute("psql", "-Upostgres", database, "-tAc", fmt.Sprintf(createTable, i))
+	}
+
+	writeFile("target-list", "public.users2\npublic.users4\npublic.users5")
+
+	out := assertedExecute(t, "./psqldef", "-Upostgres", database, "--export", "--target-file", "target-list")
+	assertEquals(t, out, fmt.Sprintf(createTable, 2)+"\n"+fmt.Sprintf(createTable, 4)+"\n"+fmt.Sprintf(createTable, 5))
+}
+
+func TestPsqldefTargetFile(t *testing.T) {
+
+	createTable := stripHeredoc(
+		`CREATE TABLE public.users%d (
+		    "id" bigint NOT NULL
+		);`)
+	modifiedCreateTable := stripHeredoc(
+		`CREATE TABLE public.users%d (
+		    "id" bigint NOT NULL,
+		    "name" character varying(30)
+		);`)
+
+	// Prepare the modified schema.sql
+	resetTestDatabase()
+	for i := 3; i <= 7; i++ {
+		mustExecute("psql", "-Upostgres", database, "-tAc", fmt.Sprintf(modifiedCreateTable, i))
+	}
+	out := assertedExecute(t, "./psqldef", "-Upostgres", database, "--export", "--file", "schema.sql")
+	writeFile("schema.sql", out)
+
+	// Run test
+	resetTestDatabase()
+	for i := 1; i <= 5; i++ {
+		mustExecute("psql", "-Upostgres", database, "-tAc", fmt.Sprintf(createTable, i))
+	}
+
+	writeFile("target-list", "public.users2\npublic.users4\npublic.users6")
+
+	apply := assertedExecute(t, "./psqldef", "-Upostgres", database, "--target-file", "target-list", "--file", "schema.sql")
+	assertEquals(t, apply,
+		applyPrefix+
+			`ALTER TABLE "public"."users4" ADD COLUMN "name" character varying(30);`+"\n"+
+			fmt.Sprintf(modifiedCreateTable, 6)+"\n"+
+			`DROP TABLE "public"."users2";`+"\n")
+}
+
 func TestPsqldefHelp(t *testing.T) {
 	_, err := execute("./psqldef", "--help")
 	if err != nil {
@@ -1384,6 +1489,7 @@ func TestMain(m *testing.M) {
 	status := m.Run()
 	_ = os.Remove("psqldef")
 	_ = os.Remove("schema.sql")
+	_ = os.Remove("target-list")
 	os.Exit(status)
 }
 

--- a/cmd/sqlite3def/sqlite3def.go
+++ b/cmd/sqlite3def/sqlite3def.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/k0kubun/sqldef/adapter/file"
 	"log"
 	"os"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/k0kubun/sqldef"
 	"github.com/k0kubun/sqldef/adapter"
+	"github.com/k0kubun/sqldef/adapter/file"
 	"github.com/k0kubun/sqldef/adapter/sqlite3"
 	"github.com/k0kubun/sqldef/schema"
 )
@@ -19,12 +19,14 @@ var version string
 // TODO: Support `sqldef schema.sql -opt val...`
 func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	var opts struct {
-		File     []string `short:"f" long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"filename" default:"-"`
-		DryRun   bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
-		Export   bool     `long:"export" description:"Just dump the current schema to stdout"`
-		SkipDrop bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
-		Help     bool     `long:"help" description:"Show this help"`
-		Version  bool     `long:"version" description:"Show this version"`
+		File       []string `short:"f" long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"filename" default:"-"`
+		DryRun     bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
+		Export     bool     `long:"export" description:"Just dump the current schema to stdout"`
+		SkipDrop   bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
+		Targets    string   `long:"targets" description:"Manage the target name (Table, View, Type, Trigger)"`
+		TargetFile string   `long:"target-file" description:"File management of --targets option"`
+		Help       bool     `long:"help" description:"Show this help"`
+		Version    bool     `long:"version" description:"Show this version"`
 	}
 
 	parser := flags.NewParser(&opts, flags.None)
@@ -45,12 +47,14 @@ func parseOptions(args []string) (adapter.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+	targets := sqldef.MargeTargets(opts.Targets, opts.TargetFile)
 	options := sqldef.Options{
 		DesiredFile: desiredFile,
 		CurrentFile: currentFile,
 		DryRun:      opts.DryRun,
 		Export:      opts.Export,
 		SkipDrop:    opts.SkipDrop,
+		Targets:     targets,
 	}
 
 	database := ""

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -1,6 +1,7 @@
 package schema
 
 type DDL interface {
+	Name() string
 	Statement() string
 }
 
@@ -262,6 +263,42 @@ func (t *Trigger) Statement() string {
 
 func (t *Type) Statement() string {
 	return t.statement
+}
+
+func (c *CreateTable) Name() string {
+	return c.table.name
+}
+
+func (c *CreateIndex) Name() string {
+	return c.tableName
+}
+
+func (a *AddIndex) Name() string {
+	return a.tableName
+}
+
+func (a *AddPrimaryKey) Name() string {
+	return a.tableName
+}
+
+func (a *AddForeignKey) Name() string {
+	return a.tableName
+}
+
+func (a *AddPolicy) Name() string {
+	return a.tableName
+}
+
+func (v *View) Name() string {
+	return v.name
+}
+
+func (t *Trigger) Name() string {
+	return t.tableName
+}
+
+func (t *Type) Name() string {
+	return t.name
 }
 
 func (t *Table) PrimaryKey() *Index {

--- a/sqldef.go
+++ b/sqldef.go
@@ -29,7 +29,6 @@ func Run(generatorMode schema.GeneratorMode, db adapter.Database, options *Optio
 	if err != nil {
 		log.Fatal(fmt.Sprintf("Error on DumpDDLs: %s", err))
 	}
-	currentDDLs = filterDDLs(currentDDLs, options)
 	currentDDLs = filterTargets(generatorMode, currentDDLs, options.Targets)
 
 	if options.Export {
@@ -40,6 +39,7 @@ func Run(generatorMode schema.GeneratorMode, db adapter.Database, options *Optio
 		}
 		return
 	}
+	currentDDLs = filterDDLs(currentDDLs, options)
 
 	sql, err := ReadFile(options.DesiredFile)
 	if err != nil {


### PR DESCRIPTION
I have added a features to avoid environment dependence.
It would be useful to use sqldef across environments. (e.g. local/dev/stg/prod)

# --ignore-partition-range (For MySQL)
```
--ignore-partition-range     Ignore the specific code of PARTITION BY RANGE
```
In MySQL, partition information exists in DumpDDL.
Currently, its presence causes a syntax error, which can be avoided by this feature.
For example, if manage partitions by date and there are differences in the environment, it can be ignore them.
See `README.md` for a sample.