### PR TITLE
Implement --config option

### DIFF
--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -35,7 +35,6 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
 		SkipDrop              bool     `long:"skip-drop" description:"Skip destructive changes such as DROP"`
 		SkipView              bool     `long:"skip-view" description:"Skip managing views (temporary feature, to be removed later)"`
-		SkipFile              string   `long:"skip-file" description:"Skip file-managed specified tables"`
 		BeforeApply           string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
 		Config                string   `long:"config" description:"YAML file to specify other options"`
 		Help                  bool     `long:"help" description:"Show this help"`
@@ -66,7 +65,6 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		DryRun:      opts.DryRun,
 		Export:      opts.Export,
 		SkipDrop:    opts.SkipDrop,
-		SkipTables:  sqldef.ParseSkipTables(opts.SkipFile),
 		BeforeApply: opts.BeforeApply,
 		Config:      database.ParseGeneratorConfig(opts.Config),
 	}

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -37,6 +37,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		SkipView              bool     `long:"skip-view" description:"Skip managing views (temporary feature, to be removed later)"`
 		SkipFile              string   `long:"skip-file" description:"Skip file-managed specified tables"`
 		BeforeApply           string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
+		Config                string   `long:"config" description:"YAML file to specify other options"`
 		Help                  bool     `long:"help" description:"Show this help"`
 		Version               bool     `long:"version" description:"Show this version"`
 	}
@@ -67,6 +68,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		SkipDrop:    opts.SkipDrop,
 		SkipTables:  sqldef.ParseSkipTables(opts.SkipFile),
 		BeforeApply: opts.BeforeApply,
+		Config:      database.ParseGeneratorConfig(opts.Config),
 	}
 
 	databaseName := ""

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -7,17 +7,18 @@ package main
 
 import (
 	"fmt"
-	"github.com/k0kubun/sqldef/cmd/testutils"
-	"github.com/k0kubun/sqldef/database"
-	"github.com/k0kubun/sqldef/database/postgres"
-	"github.com/k0kubun/sqldef/parser"
-	"github.com/k0kubun/sqldef/schema"
 	"log"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/k0kubun/sqldef/cmd/testutils"
+	"github.com/k0kubun/sqldef/database"
+	"github.com/k0kubun/sqldef/database/postgres"
+	"github.com/k0kubun/sqldef/parser"
+	"github.com/k0kubun/sqldef/schema"
 )
 
 const (
@@ -1157,6 +1158,7 @@ func TestPsqldefAddUniqueConstraintToTableInNonpublicSchema(t *testing.T) {
 		    "a" integer,
 		    "b" integer
 		);
+
 		ALTER TABLE test.dummy ADD CONSTRAINT a_b_uniq UNIQUE (a, b);
 		`))
 	assertApplyOutput(t, createTable+"\n"+alterTable, nothingModified)
@@ -1170,6 +1172,7 @@ func TestPsqldefAddUniqueConstraintToTableInNonpublicSchema(t *testing.T) {
 		    "a" integer,
 		    "b" integer
 		);
+
 		ALTER TABLE test.dummy ADD CONSTRAINT a_uniq UNIQUE (a) DEFERRABLE INITIALLY DEFERRED;
 		`))
 	assertApplyOutput(t, createTable+"\n"+alterTable, nothingModified)
@@ -1190,6 +1193,7 @@ func TestPsqldefIndexesOnExpressions(t *testing.T) {
 			CREATE TABLE "%s"."test" (
 			    "col" jsonb
 			);
+
 			CREATE UNIQUE INDEX function_index ON %s.test USING btree (jsonb_extract_path_text(col, VARIADIC ARRAY['foo'::text, 'bar'::text]));
 			`), tc.Schema, tc.Schema))
 		assertApplyOutput(t, createTable+createIndex, nothingModified)
@@ -1313,6 +1317,7 @@ func TestPsqldefExport(t *testing.T) {
 		    "c_varchar_unlimited" character varying,
 		    PRIMARY KEY ("id")
 		);
+
 		ALTER TABLE public.users ADD CONSTRAINT users_c_char_1_key UNIQUE (c_char_1);
 		`,
 	))

--- a/cmd/testutils/testutils.go
+++ b/cmd/testutils/testutils.go
@@ -83,7 +83,7 @@ func RunTest(t *testing.T, db database.Database, test TestCase, mode schema.Gene
 	if err != nil {
 		log.Fatal(err)
 	}
-	ddls, err := schema.GenerateIdempotentDDLs(mode, sqlParser, test.Current, dumpDDLs, []string{})
+	ddls, err := schema.GenerateIdempotentDDLs(mode, sqlParser, test.Current, dumpDDLs, []string{}, database.GeneratorConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func RunTest(t *testing.T, db database.Database, test TestCase, mode schema.Gene
 	if err != nil {
 		log.Fatal(err)
 	}
-	ddls, err = schema.GenerateIdempotentDDLs(mode, sqlParser, test.Desired, dumpDDLs, []string{})
+	ddls, err = schema.GenerateIdempotentDDLs(mode, sqlParser, test.Desired, dumpDDLs, []string{}, database.GeneratorConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +115,7 @@ func RunTest(t *testing.T, db database.Database, test TestCase, mode schema.Gene
 	if err != nil {
 		log.Fatal(err)
 	}
-	ddls, err = schema.GenerateIdempotentDDLs(mode, sqlParser, test.Desired, dumpDDLs, []string{})
+	ddls, err = schema.GenerateIdempotentDDLs(mode, sqlParser, test.Desired, dumpDDLs, []string{}, database.GeneratorConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -57,13 +57,13 @@ func GenerateIdempotentDDLs(mode GeneratorMode, sqlParser database.Parser, desir
 	if err != nil {
 		return nil, err
 	}
-	desiredDDLs = filterTables(desiredDDLs, skipTables, config)
+	desiredDDLs = FilterTables(desiredDDLs, skipTables, config)
 
 	currentDDLs, err := ParseDDLs(mode, sqlParser, currentSQL)
 	if err != nil {
 		return nil, err
 	}
-	currentDDLs = filterTables(currentDDLs, skipTables, config)
+	currentDDLs = FilterTables(currentDDLs, skipTables, config)
 
 	tables, err := convertDDLsToTables(currentDDLs)
 	if err != nil {
@@ -1775,7 +1775,7 @@ func generateDefaultDefinition(defaultVal Value) (string, error) {
 	}
 }
 
-func filterTables(ddls []DDL, skipTables []string, config database.GeneratorConfig) []DDL {
+func FilterTables(ddls []DDL, skipTables []string, config database.GeneratorConfig) []DDL {
 	filtered := []DDL{}
 	for _, ddl := range ddls {
 		switch stmt := ddl.(type) {

--- a/sqldef.go
+++ b/sqldef.go
@@ -19,6 +19,7 @@ type Options struct {
 	SkipDrop    bool
 	SkipTables  []string
 	BeforeApply string
+	Config      database.GeneratorConfig
 }
 
 // Main function shared by all commands
@@ -43,7 +44,7 @@ func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser dat
 	}
 	desiredDDLs := sql
 
-	ddls, err := schema.GenerateIdempotentDDLs(generatorMode, sqlParser, desiredDDLs, currentDDLs, options.SkipTables)
+	ddls, err := schema.GenerateIdempotentDDLs(generatorMode, sqlParser, desiredDDLs, currentDDLs, options.SkipTables, options.Config)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/sqldef.go
+++ b/sqldef.go
@@ -26,14 +26,24 @@ type Options struct {
 func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser database.Parser, options *Options) {
 	currentDDLs, err := db.DumpDDLs()
 	if err != nil {
-		log.Fatal(fmt.Sprintf("Error on DumpDDLs: %s", err))
+		log.Fatalf("Error on DumpDDLs: %s", err)
 	}
 
 	if options.Export {
 		if currentDDLs == "" {
 			fmt.Printf("-- No table exists --\n")
 		} else {
-			fmt.Printf("%s\n", currentDDLs)
+			ddls, err := schema.ParseDDLs(generatorMode, sqlParser, currentDDLs)
+			if err != nil {
+				log.Fatal(err)
+			}
+			ddls = schema.FilterTables(ddls, options.SkipTables, options.Config)
+			for i, ddl := range ddls {
+				if i > 0 {
+					fmt.Println()
+				}
+				fmt.Printf("%s;\n", ddl.Statement())
+			}
 		}
 		return
 	}


### PR DESCRIPTION
Close https://github.com/k0kubun/sqldef/issues/246

With a YAML file like below, you can specify tables that sqldef should manage.

```yml
target_tables: |
  users
  users_\d+
```

You can specify the config file like `mysqldef --config sqldef.yml`.