### PR TITLE
Cross-compile darwin targets with osxcross

### DIFF
--- a/.github/workflows/sqldef.yml
+++ b/.github/workflows/sqldef.yml
@@ -10,6 +10,9 @@ on:
       - opened
       - synchronize
       - reopened
+env:
+  OSXCROSS_REVISION: 4287300a5c96397a2ee9ab3942e66578a1982031
+  XCODE_VERSION: '12.4'
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -59,12 +62,6 @@ jobs:
           - { GOOS: linux,   GOARCH: arm,   EXT: tar.gz, ZIG_CFLAGS: '-target arm-linux-musleabi' }
           - { GOOS: windows, GOARCH: amd64, EXT: zip,    ZIG_CFLAGS: '-target x86_64-windows' }
           - { GOOS: windows, GOARCH: '386', EXT: zip,    ZIG_CFLAGS: '-target i386-windows' }
-          - { GOOS: darwin,  GOARCH: amd64, EXT: zip,    ZIG_CFLAGS: '-target x86_64-macos
-                            -mmacosx-version-min=10.14 -isysroot /home/runner/work/sqldef/sqldef/MacOSX.sdk -iwithsysroot /usr/include -iframeworkwithsysroot /System/Library/Frameworks',
-              CGO_LDFLAGS: '-mmacosx-version-min=10.14 --sysroot /home/runner/work/sqldef/sqldef/MacOSX.sdk -F/System/Library/Frameworks -L/usr/lib' }
-          - { GOOS: darwin,  GOARCH: arm64, EXT: zip,    ZIG_CFLAGS: '-target aarch64-macos
-                            -mmacosx-version-min=11.1  -isysroot /home/runner/work/sqldef/sqldef/MacOSX.sdk -iwithsysroot /usr/include -iframeworkwithsysroot /System/Library/Frameworks',
-              CGO_LDFLAGS: '-mmacosx-version-min=11.1  --sysroot /home/runner/work/sqldef/sqldef/MacOSX.sdk -F/System/Library/Frameworks -L/usr/lib' }
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -89,11 +86,85 @@ jobs:
           name: sqldef-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
           path: package/*def_${{ matrix.GOOS }}_${{ matrix.GOARCH }}.${{ matrix.EXT }}
 
+  macos-sdk:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/cache@v2
+        id: macos-sdk-cache
+        with:
+          key: macos-sdk-${{ env.OSXCROSS_REVISION }}-${{ env.XCODE_VERSION }}
+          path: osxcross/tarballs
+      - name: Package MacOSX SDK
+        if: steps.macos-sdk-cache.outputs.cache-hit != 'true'
+        run: |
+          curl -sSLf https://github.com/tpoechtrager/osxcross/archive/${OSXCROSS_REVISION}.tar.gz | tar zxf -
+          mv osxcross-${OSXCROSS_REVISION} osxcross
+          cd osxcross
+          XCODEDIR=/Applications/Xcode_${XCODE_VERSION}.app tools/gen_sdk_package.sh
+          mv MacOSX*.sdk.tar.xz tarballs/
+
+  osxcross:
+    runs-on: ubuntu-latest
+    needs:
+      - macos-sdk
+    steps:
+      - name: Download osxcross
+        run: |
+          curl -sSLf https://github.com/tpoechtrager/osxcross/archive/${OSXCROSS_REVISION}.tar.gz | tar zxf -
+          mv osxcross-${OSXCROSS_REVISION} osxcross
+      - uses: actions/cache@v2
+        with:
+          key: macos-sdk-${{ env.OSXCROSS_REVISION }}-${{ env.XCODE_VERSION }}
+          path: osxcross/tarballs
+      - uses: actions/cache@v2
+        id: osxcross-cache
+        with:
+          key: osxcross-${{ runner.os }}-${{ env.OSXCROSS_REVISION }}-${{ env.XCODE_VERSION }}
+          path: osxcross/target
+      - name: Build osxcross
+        if: steps.osxcross-cache.outputs.cache-hit != 'true'
+        run: UNATTENDED=1 ./build.sh
+        working-directory: osxcross
+
+  osxcross-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { GOOS: darwin, GOARCH: amd64, EXT: zip, CC: x86_64-apple-darwin20.2-clang }
+          - { GOOS: darwin, GOARCH: arm64, EXT: zip, CC: aarch64-apple-darwin20.2-clang }
+      fail-fast: false
+    needs:
+      - osxcross
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+      - uses: actions/cache@v2
+        id: osxcross-cache
+        with:
+          key: osxcross-${{ runner.os }}-${{ env.OSXCROSS_REVISION }}-${{ env.XCODE_VERSION }}
+          path: osxcross/target
+
+      - name: make package-${{ matrix.EXT }}
+        run: |
+          export PATH="$PWD/osxcross/target/bin:$PATH"
+          make package-${{ matrix.EXT }} GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} CC=${{ matrix.CC }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: sqldef-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
+          path: package/*def_${{ matrix.GOOS }}_${{ matrix.GOARCH }}.${{ matrix.EXT }}
+
   release:
     runs-on: ubuntu-latest
     needs:
       - test
       - package
+      - osxcross-build
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # This doesn't work for psqldef due to lib/pq
-GOFLAGS := -tags netgo -installsuffix netgo -ldflags '-w -s --extldflags "-static" -X main.version=$(shell git describe --tags --abbrev=0)'
+GOFLAGS := -tags netgo -installsuffix netgo -ldflags '-w -s -X main.version=$(shell git describe --tags --abbrev=0)'
 GOVERSION=$(shell go version)
 GOOS=$(word 1,$(subst /, ,$(lastword $(GOVERSION))))
 GOARCH=$(word 2,$(subst /, ,$(lastword $(GOVERSION))))
@@ -8,6 +8,7 @@ SHELL=/bin/bash
 SQLDEF=$(shell pwd)
 MACOS_VERSION := 11.3
 ZIG_CFLAGS := -target $(shell uname -m)-$(shell uname -s | tr '[:upper:]' '[:lower:]')
+CC := zig cc $(ZIG_CFLAGS)
 CGO_LDFLAGS :=
 
 .PHONY: all build clean deps package package-zip package-targz
@@ -28,7 +29,7 @@ build:
 	cd cmd/sqlite3def  && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/sqlite3def
 	cd cmd/mssqldef    && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS) -o ../../$(BUILD_DIR)/mssqldef
 	if [[ $(GOOS) != windows ]]; then \
-		cd cmd/psqldef && CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) CC="zig cc $(ZIG_CFLAGS)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
+		cd cmd/psqldef && CGO_ENABLED=1 GOOS=$(GOOS) GOARCH=$(GOARCH) CC="$(CC)" CGO_LDFLAGS="$(CGO_LDFLAGS)" \
 			go build $(GOFLAGS) -o ../../$(BUILD_DIR)/psqldef; \
 	fi;
 


### PR DESCRIPTION
Fix https://github.com/k0kubun/sqldef/issues/270

There are some challenges in cross-compiling cgo programs for darwin with `zig cc` https://github.com/ziglang/zig/issues/9050#issuecomment-859939664. While they gave a solution to the mentioned problems, even if we use all of them for sqldef, darwin binaries result in a segmentation fault on `runtime.cgocall` like #270.

This implementation is based on https://github.com/itamae-kitchen/mitamae/pull/105. I confirmed that both amd64 and arm64 binaries generated by it don't cause a segmentation fault when it calls the cgo path, unlike the ones generated by `zig cc`. So I'm switching to `zig cc` for darwin builds.