### PR TITLE
[mysqldef] Add --ssl-mode option.

### DIFF
--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/k0kubun/sqldef/database/file"
@@ -28,6 +29,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		Host                  string   `short:"h" long:"host" description:"Host to connect to the MySQL server" value-name:"host_name" default:"127.0.0.1"`
 		Port                  uint     `short:"P" long:"port" description:"Port used for the connection" value-name:"port_num" default:"3306"`
 		Socket                string   `short:"S" long:"socket" description:"The socket file to use for connection" value-name:"socket"`
+		SslMode               string   `long:"ssl-mode" description:"SSL connection mode(PREFERRED,REQUIRED,DISABLED)." value-name:"ssl_mode" default:"PREFERRED"`
 		Prompt                bool     `long:"password-prompt" description:"Force MySQL user password prompt"`
 		EnableCleartextPlugin bool     `long:"enable-cleartext-plugin" description:"Enable/disable the clear text authentication plugin"`
 		File                  []string `long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
@@ -83,6 +85,19 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		databaseName = args[0]
 	}
 
+	switch strings.ToLower(opts.SslMode) {
+	case "disabled":
+		opts.SslMode = "false"
+	case "preferred":
+		opts.SslMode = "preferred"
+	case "required":
+		opts.SslMode = "true"
+	default:
+		fmt.Printf("Wrong value for ssl-mode is given: %v\n\n", opts.SslMode)
+		parser.WriteHelp(os.Stdout)
+		os.Exit(1)
+	}
+
 	password, ok := os.LookupEnv("MYSQL_PWD")
 	if !ok {
 		password = opts.Password
@@ -106,6 +121,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		Socket:                     opts.Socket,
 		MySQLEnableCleartextPlugin: opts.EnableCleartextPlugin,
 		SkipView:                   opts.SkipView,
+		SslMode:                    opts.SslMode,
 	}
 	return config, &options
 }

--- a/database/database.go
+++ b/database/database.go
@@ -22,6 +22,7 @@ type Config struct {
 	// Only MySQL
 	MySQLEnableCleartextPlugin bool
 	SkipView                   bool
+	SslMode                    string
 }
 
 type GeneratorConfig struct {

--- a/database/mysql/database.go
+++ b/database/mysql/database.go
@@ -147,7 +147,7 @@ func mysqlBuildDSN(config database.Config) string {
 	c.Passwd = config.Password
 	c.DBName = config.DbName
 	c.AllowCleartextPasswords = config.MySQLEnableCleartextPlugin
-	c.TLSConfig = "preferred"
+	c.TLSConfig = config.SslMode
 	if config.Socket == "" {
 		c.Net = "tcp"
 		c.Addr = fmt.Sprintf("%s:%d", config.Host, config.Port)


### PR DESCRIPTION
When I tried to connect Aurora MySQL 1.x, but mysqldef does not work.
( note : Windows 10 21H2 19044.1889, mysqldef: v0.13.7, mysql cli:  v8.0.30 )

```
>mysqldef -u username -h localhost --export dbname
2022/08/24 13:45:37 Error on DumpDDLs: tls: server selected unsupported protocol version 301
```

I think this is caused by old Aurora MySQL 1.x support only TLS 1.0.
(see https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Security.html )

For example, I could connect by mysql cli tool with `--ssl-mode=DISABLED` option.
And I cound connect to Aurora MySQL 2.x with latest mysqldef.

So I added --ssl-mode option to mysqldef.
Available values are `DISABLED, REQUIRED, PREFERRED` and default value is `PREFERRED`.
( note: I don't accept `VERIFY_CA` and `VERIFY_IDENTITY` because go-sql-driver/mysql doest not support these options. )

Tests for mysqldef is passed.

![2022-08-26 11_21_54](https://user-images.githubusercontent.com/1624129/186804348-d321be5d-c624-4265-9a2a-88dc840a9578.jpg)
.