### PR TITLE
Separate comment schema for each table.

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -301,3 +301,30 @@ Comment:
     COMMENT ON TABLE hoge is 'hoge table';
     COMMENT ON COLUMN hoge.id is 'hoge id';
     COMMENT ON COLUMN hoge.foo is 'foo comment';
+
+MultipleComments:
+  current: |
+    CREATE TABLE "public"."hoge" (
+      "id" bigserial NOT NULL,
+      PRIMARY KEY ("id")
+    );
+    CREATE TABLE "public"."bar" (
+      "id" bigserial NOT NULL,
+      PRIMARY KEY ("id")
+    );
+
+    COMMENT ON COLUMN hoge.id is 'hoge id';
+  desired: |
+    CREATE TABLE "public"."hoge" (
+      "id" bigserial NOT NULL,
+      PRIMARY KEY ("id")
+    );
+    CREATE TABLE "public"."bar" (
+      "id" bigserial NOT NULL,
+      PRIMARY KEY ("id")
+    );
+
+    COMMENT ON COLUMN hoge.id is 'hoge id';
+    COMMENT ON COLUMN bar.id is 'bar id';
+  output: |
+    COMMENT ON COLUMN bar.id is 'bar id';

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -730,9 +730,10 @@ func (d *PostgresDatabase) getComments(table string) ([]string, error) {
 		inner join information_schema.columns c on (
 			pgd.objsubid   = c.ordinal_position and
 			c.table_schema = st.schemaname and
-			c.table_name   = st.relname
+			c.table_name   = st.relname and
+			st.relname = $1
 		);
-	`)
+	`, table)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I found a bug when dumping schema on postgresql where column comments are expanded to all tables.
It seems that the process of retrieving comments for the specified table is omitting the specification of the table.

I fixed a problem when retrieving comments by adding a `where` condition to filter by table.