### PR TITLE
[psqldef] Introduced extension support

### DIFF
--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -152,9 +152,9 @@ func TestPsqldefCreateTableNotNull(t *testing.T) {
 
 func TestPsqldefCitextExtension(t *testing.T) {
 	resetTestDatabase()
-	mustExecuteSQL("CREATE EXTENSION citext;")
 
 	createTable := stripHeredoc(`
+		CREATE EXTENSION citext;
 		CREATE TABLE users (
 		  name citext
 		);
@@ -169,9 +169,9 @@ func TestPsqldefCitextExtension(t *testing.T) {
 
 func TestPsqldefIgnoreExtension(t *testing.T) {
 	resetTestDatabase()
-	mustExecuteSQL("CREATE EXTENSION pg_buffercache;")
 
 	createTable := stripHeredoc(`
+		CREATE EXTENSION pg_buffercache;
 		CREATE TABLE users (
 		  id bigint NOT NULL,
 		  name text,

--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -343,3 +343,27 @@ CreateViewCast:
       amount::numeric(10,2) as amount_num
     from hoge;
   output: ''
+
+CreateExtension:
+  current: |
+    CREATE EXTENSION pgcrypto;
+  desired: |
+    CREATE EXTENSION pgcrypto;
+    CREATE EXTENSION btree_gist;
+  output: |
+    CREATE EXTENSION btree_gist;
+
+DropExtension:
+  current: |
+    CREATE EXTENSION pgcrypto;
+    CREATE EXTENSION btree_gist;
+  desired:
+    CREATE EXTENSION btree_gist;
+  output: |
+    DROP EXTENSION "pgcrypto";
+
+CreateExtensionIfNotExists:
+  desired: |
+    CREATE EXTENSION IF NOT EXISTS pgcrypto;
+  output: |
+    CREATE EXTENSION IF NOT EXISTS pgcrypto;

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -70,6 +70,8 @@ func (p PostgresParser) parseStmt(node *pgquery.Node) (parser.Statement, error) 
 		return p.parseViewStmt(stmt.ViewStmt)
 	case *pgquery.Node_CommentStmt:
 		return p.parseCommentStmt(stmt.CommentStmt)
+	case *pgquery.Node_CreateExtensionStmt:
+		return p.parseExtensionStmt(stmt.CreateExtensionStmt)
 	default:
 		return nil, fmt.Errorf("unknown node in parseStmt: %#v", stmt)
 	}
@@ -247,6 +249,15 @@ func (p PostgresParser) parseTableName(relation *pgquery.RangeVar) (string, stri
 		return "", "", fmt.Errorf("unhandled node in parseTableName: %#v", relation)
 	}
 	return relation.Schemaname, relation.Relname, nil
+}
+
+func (p PostgresParser) parseExtensionStmt(stmt *pgquery.CreateExtensionStmt) (parser.Statement, error) {
+	return &parser.DDL{
+		Action: parser.CreateExtensionStr,
+		Extension: &parser.Extension{
+			Name: stmt.Extname,
+		},
+	}, nil
 }
 
 func (p PostgresParser) parseColumnDef(columnDef *pgquery.ColumnDef) (*parser.ColumnDefinition, error) {

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -506,28 +506,30 @@ type DDL struct {
 	Trigger       *Trigger
 	Type          *Type
 	Comment       *Comment
+	Extension     *Extension
 }
 
 // DDL strings.
 const (
-	CreateStr        = "create"
-	AlterStr         = "alter"
-	DropStr          = "drop"
-	RenameStr        = "rename"
-	TruncateStr      = "truncate"
-	CreateVindexStr  = "create vindex"
-	AddColVindexStr  = "add vindex"
-	DropColVindexStr = "drop vindex"
-	AddIndexStr      = "add index"
-	CreateIndexStr   = "create index"
-	AddPrimaryKeyStr = "add primary key"
-	AddForeignKeyStr = "add foreign key"
-	CreatePolicyStr  = "create policy"
-	CreateViewStr    = "create view"
-	CreateMatViewStr = "create materialized view"
-	CreateTriggerStr = "create trigger"
-	CreateTypeStr    = "create type"
-	CommentStr       = "comment"
+	CreateStr          = "create"
+	AlterStr           = "alter"
+	DropStr            = "drop"
+	RenameStr          = "rename"
+	TruncateStr        = "truncate"
+	CreateVindexStr    = "create vindex"
+	AddColVindexStr    = "add vindex"
+	DropColVindexStr   = "drop vindex"
+	AddIndexStr        = "add index"
+	CreateIndexStr     = "create index"
+	AddPrimaryKeyStr   = "add primary key"
+	AddForeignKeyStr   = "add foreign key"
+	CreatePolicyStr    = "create policy"
+	CreateViewStr      = "create view"
+	CreateMatViewStr   = "create materialized view"
+	CreateTriggerStr   = "create trigger"
+	CreateTypeStr      = "create type"
+	CommentStr         = "comment"
+	CreateExtensionStr = "create extension"
 )
 
 // Format formats the node.
@@ -1145,6 +1147,10 @@ type Policy struct {
 	To         []ColIdent
 	Using      *Where
 	WithCheck  *Where
+}
+
+type Extension struct {
+	Name string
 }
 
 type Permissive string

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -238,6 +238,11 @@ type Comment struct {
 	comment   parser.Comment
 }
 
+type Extension struct {
+	statement string
+	extension parser.Extension
+}
+
 func (c *CreateTable) Statement() string {
 	return c.statement
 }
@@ -275,6 +280,10 @@ func (t *Type) Statement() string {
 }
 
 func (t *Comment) Statement() string {
+	return t.statement
+}
+
+func (t *Extension) Statement() string {
 	return t.statement
 }
 

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -438,6 +438,11 @@ func parseDDL(mode GeneratorMode, ddl string, stmt parser.Statement) (DDL, error
 				statement: ddl,
 				comment:   *stmt.Comment,
 			}, nil
+		} else if stmt.Action == parser.CreateExtensionStr {
+			return &Extension{
+				statement: ddl,
+				extension: *stmt.Extension,
+			}, nil
 		} else {
 			return nil, fmt.Errorf(
 				"unsupported type of DDL action '%s': %s",


### PR DESCRIPTION
`EXTENSION` to be managed in the schema file.

New supported syntax is `CREATE EXTENSION xxx`.
Version checking for extension is not yet supported 🙏 

NOTE: In environments already using any EXTENSION, if you try to apply before adding the extension to the schema file, `DROP EXTENSION xxx` will be applied. Be sure to add `CREATE EXTENSION xxx` to the schema file before applying.
