### PR TITLE
Replace get subcommand to install

### DIFF
--- a/parser/Makefile
+++ b/parser/Makefile
@@ -20,7 +20,7 @@ all: parser.go
 
 goyacc:
 	@if ! which goyacc > /dev/null; then \
-	  go get golang.org/x/tools/cmd/goyacc; \
+	  go install golang.org/x/tools/cmd/goyacc; \
 	fi
 
 parser.go: goyacc parser.y


### PR DESCRIPTION
I could not install goyacc on Go 1.19.3 by running `make goyacc` due to command was using `go get`.
This PR replaces go get with go install.

> In Go 1.18, go get will no longer build packages; it will only be used to add, update, or remove dependencies in go.mod. Specifically, go get will always act as if the -d flag were enabled.

https://go.dev/doc/go-get-install-deprecation