### PR TITLE
Add DesiredDDLs option to pass DDLs as string

### DIFF
--- a/cmd/mssqldef/mssqldef.go
+++ b/cmd/mssqldef/mssqldef.go
@@ -53,8 +53,17 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+
+	var desiredDDLs string
+	if !opts.Export {
+		desiredDDLs, err = sqldef.ReadFile(desiredFile)
+		if err != nil {
+			log.Fatalf("Failed to read '%s': %s", desiredFile, err)
+		}
+	}
+
 	options := sqldef.Options{
-		DesiredFile: desiredFile,
+		DesiredDDLs: desiredDDLs,
 		CurrentFile: currentFile,
 		DryRun:      opts.DryRun,
 		Export:      opts.Export,

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -62,8 +62,17 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+
+	var desiredDDLs string
+	if !opts.Export {
+		desiredDDLs, err = sqldef.ReadFile(desiredFile)
+		if err != nil {
+			log.Fatalf("Failed to read '%s': %s", desiredFile, err)
+		}
+	}
+
 	options := sqldef.Options{
-		DesiredFile: desiredFile,
+		DesiredDDLs: desiredDDLs,
 		CurrentFile: currentFile,
 		DryRun:      opts.DryRun,
 		Export:      opts.Export,

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -56,8 +56,17 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+
+	var desiredDDLs string
+	if !opts.Export {
+		desiredDDLs, err = sqldef.ReadFile(desiredFile)
+		if err != nil {
+			log.Fatalf("Failed to read '%s': %s", desiredFile, err)
+		}
+	}
+
 	options := sqldef.Options{
-		DesiredFile: desiredFile,
+		DesiredDDLs: desiredDDLs,
 		CurrentFile: currentFile,
 		DryRun:      opts.DryRun,
 		Export:      opts.Export,

--- a/cmd/sqlite3def/sqlite3def.go
+++ b/cmd/sqlite3def/sqlite3def.go
@@ -47,8 +47,17 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	}
 
 	desiredFile, currentFile := sqldef.ParseFiles(opts.File)
+
+	var desiredDDLs string
+	if !opts.Export {
+		desiredDDLs, err = sqldef.ReadFile(desiredFile)
+		if err != nil {
+			log.Fatalf("Failed to read '%s': %s", desiredFile, err)
+		}
+	}
+
 	options := sqldef.Options{
-		DesiredFile: desiredFile,
+		DesiredDDLs: desiredDDLs,
 		CurrentFile: currentFile,
 		DryRun:      opts.DryRun,
 		Export:      opts.Export,

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"github.com/k0kubun/sqldef"
 	"github.com/k0kubun/sqldef/cmd/testutils"
 	"github.com/k0kubun/sqldef/database"
 	"github.com/k0kubun/sqldef/database/sqlite3"
@@ -187,32 +186,6 @@ func TestSQLite3defVirtualTable(t *testing.T) {
 	assertEquals(t, actual, applyPrefix+createTableRtreeA)
 	actual = assertedExecute(t, "./sqlite3def", "--config", "config.yml", "--file", "schema.sql", "sqlite3def_test")
 	assertEquals(t, actual, nothingModified)
-}
-
-func TestSQLite3defFileSystem(t *testing.T) {
-	resetTestDatabase()
-
-	createTable := stripHeredoc(`
-		CREATE TABLE bigdata (
-		  data integer
-		);
-		`,
-	)
-
-	db, err := connectDatabase()
-	if err != nil {
-		t.Fatal(err)
-	}
-	sqldef.Run(
-		schema.GeneratorModeSQLite3,
-		db,
-		database.NewParser(parser.ParserModeSQLite3),
-		&sqldef.Options{
-			DesiredDDLs: createTable,
-		},
-	)
-	writeFile("schema.sql", createTable)
-	assertApplyOutput(t, createTable, nothingModified)
 }
 
 func TestSQLite3defHelp(t *testing.T) {

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -198,14 +198,6 @@ func TestSQLite3defFileSystem(t *testing.T) {
 		);
 		`,
 	)
-	writeFile("schema.sql", createTable)
-
-	createTable2 := stripHeredoc(`
-		CREATE TABLE bigdata2 (
-		  data integer
-		);
-		`,
-	)
 
 	db, err := connectDatabase()
 	if err != nil {
@@ -216,11 +208,11 @@ func TestSQLite3defFileSystem(t *testing.T) {
 		db,
 		database.NewParser(parser.ParserModeSQLite3),
 		&sqldef.Options{
-			DesiredFile: "schema.sql",
-			DesiredDDLs: createTable2,
+			DesiredDDLs: createTable,
 		},
 	)
-	assertApplyOutput(t, createTable+createTable2, nothingModified)
+	writeFile("schema.sql", createTable)
+	assertApplyOutput(t, createTable, nothingModified)
 }
 
 func TestSQLite3defHelp(t *testing.T) {

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"github.com/k0kubun/sqldef"
 	"github.com/k0kubun/sqldef/cmd/testutils"
 	"github.com/k0kubun/sqldef/database"
 	"github.com/k0kubun/sqldef/database/sqlite3"
@@ -186,6 +187,40 @@ func TestSQLite3defVirtualTable(t *testing.T) {
 	assertEquals(t, actual, applyPrefix+createTableRtreeA)
 	actual = assertedExecute(t, "./sqlite3def", "--config", "config.yml", "--file", "schema.sql", "sqlite3def_test")
 	assertEquals(t, actual, nothingModified)
+}
+
+func TestSQLite3defFileSystem(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := stripHeredoc(`
+		CREATE TABLE bigdata (
+		  data integer
+		);
+		`,
+	)
+	writeFile("schema.sql", createTable)
+
+	createTable2 := stripHeredoc(`
+		CREATE TABLE bigdata2 (
+		  data integer
+		);
+		`,
+	)
+
+	db, err := connectDatabase()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqldef.Run(
+		schema.GeneratorModeSQLite3,
+		db,
+		database.NewParser(parser.ParserModeSQLite3),
+		&sqldef.Options{
+			DesiredFile: "schema.sql",
+			DesiredDDLs: createTable2,
+		},
+	)
+	assertApplyOutput(t, createTable+createTable2, nothingModified)
 }
 
 func TestSQLite3defHelp(t *testing.T) {

--- a/sqldef.go
+++ b/sqldef.go
@@ -12,7 +12,6 @@ import (
 )
 
 type Options struct {
-	DesiredFile string
 	DesiredDDLs string
 	CurrentFile string
 	DryRun      bool
@@ -24,10 +23,6 @@ type Options struct {
 
 // Main function shared by all commands
 func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser database.Parser, options *Options) {
-	if options.DesiredFile != "" && options.DesiredDDLs != "" {
-		log.Fatalf("The options are exclusive - DesiredFile: %s, DesiredDDLs: %s", options.DesiredFile, options.DesiredDDLs)
-	}
-
 	currentDDLs, err := db.DumpDDLs()
 	if err != nil {
 		log.Fatalf("Error on DumpDDLs: %s", err)
@@ -52,18 +47,7 @@ func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser dat
 		return
 	}
 
-	var desiredDDLs string
-	if options.DesiredFile != "" {
-		sql, err := ReadFile(options.DesiredFile)
-		if err != nil {
-			log.Fatalf("Failed to read '%s': %s", options.DesiredFile, err)
-		}
-		desiredDDLs = sql
-	} else if options.DesiredDDLs != "" {
-		desiredDDLs = options.DesiredDDLs
-	}
-
-	ddls, err := schema.GenerateIdempotentDDLs(generatorMode, sqlParser, desiredDDLs, currentDDLs, options.Config)
+	ddls, err := schema.GenerateIdempotentDDLs(generatorMode, sqlParser, options.DesiredDDLs, currentDDLs, options.Config)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/sqldef.go
+++ b/sqldef.go
@@ -13,6 +13,7 @@ import (
 
 type Options struct {
 	DesiredFile string
+	DesiredDDLs string
 	CurrentFile string
 	DryRun      bool
 	Export      bool
@@ -51,7 +52,7 @@ func Run(generatorMode schema.GeneratorMode, db database.Database, sqlParser dat
 	if err != nil {
 		log.Fatalf("Failed to read '%s': %s", options.DesiredFile, err)
 	}
-	desiredDDLs := sql
+	desiredDDLs := sql + options.DesiredDDLs
 
 	ddls, err := schema.GenerateIdempotentDDLs(generatorMode, sqlParser, desiredDDLs, currentDDLs, options.Config)
 	if err != nil {
@@ -93,6 +94,10 @@ func ParseFiles(files []string) (string, string) {
 }
 
 func ReadFile(filepath string) (string, error) {
+	if filepath == "" {
+		return "", nil
+	}
+
 	var err error
 	var buf []byte
 


### PR DESCRIPTION
Added option to `sqldef.Run()` to pass DDLs as a string so that sqldef can be used in single binary without specifying schema file on the filesystem.

At first I was going to use `fs.FS` (#314) , but then I decided it was unnecessary, so I created this pull request instead. See the PR  for use cases which requires this this fix and the fear that interface changes will break code compatibility.