### PR TITLE
Change index types to upper case in ALTER TABLE

### DIFF
--- a/cmd/mssqldef/mssqldef_test.go
+++ b/cmd/mssqldef/mssqldef_test.go
@@ -497,7 +497,7 @@ func TestMssqldefCreateTableAddPrimaryKeyConstraint(t *testing.T) {
 	)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE [dbo].[users] ADD CONSTRAINT [pk_users] primary key CLUSTERED ([id] desc);\n",
+		"ALTER TABLE [dbo].[users] ADD CONSTRAINT [pk_users] PRIMARY KEY CLUSTERED ([id] desc);\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }

--- a/cmd/mssqldef/mssqldef_test.go
+++ b/cmd/mssqldef/mssqldef_test.go
@@ -469,7 +469,7 @@ func TestMssqldefCreateTableAddPrimaryKey(t *testing.T) {
 	)
 
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE [dbo].[users] ADD primary key CLUSTERED ([id]);\n",
+		"ALTER TABLE [dbo].[users] ADD PRIMARY KEY CLUSTERED ([id]);\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }

--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -77,7 +77,7 @@ func TestMysqldefCreateTableChangePrimaryKey(t *testing.T) {
 
 	assertApplyOutput(t, createTable, applyPrefix+
 		"ALTER TABLE `friends` DROP PRIMARY KEY;\n"+
-		"ALTER TABLE `friends` ADD primary key (`user_id`, `friend_id`);\n",
+		"ALTER TABLE `friends` ADD PRIMARY KEY (`user_id`, `friend_id`);\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -105,7 +105,7 @@ func TestMysqldefCreateTableAddAutoIncrementPrimaryKey(t *testing.T) {
 
 	assertApplyOutput(t, createTable, applyPrefix+
 		"ALTER TABLE `users` ADD COLUMN `id` bigint NOT NULL FIRST;\n"+
-		"ALTER TABLE `users` ADD primary key (`id`);\n"+
+		"ALTER TABLE `users` ADD PRIMARY KEY (`id`);\n"+
 		"ALTER TABLE `users` CHANGE COLUMN `id` `id` bigint NOT NULL AUTO_INCREMENT;\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
@@ -159,7 +159,7 @@ func TestMysqldefCreateTableAddIndexWithKeyLength(t *testing.T) {
 		  INDEX index_name(name(255))
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD index `index_name` (`name`(255));\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD INDEX `index_name` (`name`(255));\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -484,7 +484,7 @@ func TestMysqldefIndexOption(t *testing.T) {
 		  KEY index_id (id) USING BTREE
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD key `index_id` (`id`) using BTREE;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD KEY `index_id` (`id`) using BTREE;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -526,7 +526,7 @@ func TestMysqldefFulltextIndex(t *testing.T) {
 		  FULLTEXT KEY title_fulltext_index (title) /*!50100 WITH PARSER ngram */
 		);`,
 	)
-	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `posts` ADD fulltext key `title_fulltext_index` (`title`) WITH parser ngram;\n")
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `posts` ADD FULLTEXT KEY `title_fulltext_index` (`title`) WITH parser ngram;\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -579,8 +579,8 @@ func TestMysqldefCreateTableKey(t *testing.T) {
 		`,
 	)
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE `users` ADD key `index_name` (`name`);\n"+
-		"ALTER TABLE `users` ADD unique key `index_created_at` (`created_at`);\n",
+		"ALTER TABLE `users` ADD KEY `index_name` (`name`);\n"+
+		"ALTER TABLE `users` ADD UNIQUE KEY `index_created_at` (`created_at`);\n",
 	)
 	assertApplyOutput(t, createTable, nothingModified)
 }
@@ -781,7 +781,7 @@ func TestMysqldefKeywordIndexColumns(t *testing.T) {
 		"  KEY `index_character`(`character`)\n" +
 		");\n"
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE `tools` ADD key `index_character` (`character`);\n")
+		"ALTER TABLE `tools` ADD KEY `index_character` (`character`);\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -1238,7 +1238,7 @@ func TestMysqldefIndexWithDot(t *testing.T) {
 		"  KEY `account.id`(account_id)\n" +
 		");\n"
 	assertApplyOutput(t, createTable, applyPrefix+
-		"ALTER TABLE `users` ADD key `account.id` (`account_id`);\n")
+		"ALTER TABLE `users` ADD KEY `account.id` (`account_id`);\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 
@@ -1264,9 +1264,9 @@ func TestMysqldefChangeIndexCombination(t *testing.T) {
 		");\n"
 	assertApplyOutput(t, createTable, applyPrefix+
 		"ALTER TABLE `users` DROP INDEX `index_users1`;\n"+
-		"ALTER TABLE `users` ADD key `index_users1` (`account_id`, `name`);\n"+
+		"ALTER TABLE `users` ADD KEY `index_users1` (`account_id`, `name`);\n"+
 		"ALTER TABLE `users` DROP INDEX `index_users2`;\n"+
-		"ALTER TABLE `users` ADD key `index_users2` (`account_id`);\n")
+		"ALTER TABLE `users` ADD KEY `index_users2` (`account_id`);\n")
 	assertApplyOutput(t, createTable, nothingModified)
 }
 

--- a/cmd/mysqldef/tests.yml
+++ b/cmd/mysqldef/tests.yml
@@ -59,7 +59,7 @@ CreateTableAddPrimaryKeyInColumn:
     );
   output: |
     ALTER TABLE `users` CHANGE COLUMN `name` `name` varchar(20) NOT NULL;
-    ALTER TABLE `users` ADD primary key (`name`);
+    ALTER TABLE `users` ADD PRIMARY KEY (`name`);
 CreateTableAddPrimaryKey:
   current: |
     CREATE TABLE users (
@@ -73,7 +73,7 @@ CreateTableAddPrimaryKey:
       PRIMARY KEY (id)
     );
   output: |
-    ALTER TABLE `users` ADD primary key (`id`);
+    ALTER TABLE `users` ADD PRIMARY KEY (`id`);
 CreateTableAddAutoIncrement:
   current: |
     CREATE TABLE users (
@@ -163,7 +163,7 @@ CreateTableWithAutoIncrementPrimaryKeyAndAddMorePrimaryKey:
   output: |
     ALTER TABLE `friends` CHANGE COLUMN `id` `id` bigint NOT NULL;
     ALTER TABLE `friends` DROP PRIMARY KEY;
-    ALTER TABLE `friends` ADD primary key (`id`, `other_id`);
+    ALTER TABLE `friends` ADD PRIMARY KEY (`id`, `other_id`);
     ALTER TABLE `friends` CHANGE COLUMN `id` `id` bigint NOT NULL AUTO_INCREMENT;
   min_version: '8.0'
 CreateTableWithSpatialTypesAndSpatialKey:
@@ -179,7 +179,7 @@ CreateTableWithSpatialTypesAndSpatialKey:
     );
   output: |
     ALTER TABLE `users` ADD COLUMN `location` point NOT NULL AFTER `id`;
-    ALTER TABLE `users` ADD spatial key `index_users_location` (`location`);
+    ALTER TABLE `users` ADD SPATIAL KEY `index_users_location` (`location`);
 CreateTableWithSpatialTypesSRIDSpecified:
   current: |
     CREATE TABLE users (

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -191,7 +191,7 @@ func TestPsqldefCreateTablePrimaryKey(t *testing.T) {
 	)
 	assertApplyOutput(t, createTable, applyPrefix+stripHeredoc(`
 		ALTER TABLE "public"."users" ADD COLUMN "id" bigint NOT NULL;
-		ALTER TABLE "public"."users" ADD primary key ("id");
+		ALTER TABLE "public"."users" ADD PRIMARY KEY ("id");
 		`,
 	))
 	assertApplyOutput(t, createTable, nothingModified)

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -314,7 +314,7 @@ func (t *Table) PrimaryKey() *Index {
 
 	return &Index{
 		name:      "PRIMARY",
-		indexType: "PRIMARY KEY",
+		indexType: "primary key",
 		columns:   primaryColumns,
 		primary:   true,
 		unique:    true,

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -314,7 +314,7 @@ func (t *Table) PrimaryKey() *Index {
 
 	return &Index{
 		name:      "PRIMARY",
-		indexType: "primary key",
+		indexType: "PRIMARY KEY",
 		columns:   primaryColumns,
 		primary:   true,
 		unique:    true,

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -1108,7 +1108,7 @@ func (g *Generator) generateAddIndex(table string, index Index) string {
 		ddl := fmt.Sprintf(
 			"ALTER TABLE %s ADD %s",
 			g.escapeTableName(table),
-			index.indexType,
+			strings.ToUpper(index.indexType),
 		)
 
 		if !index.primary {

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -1099,7 +1099,7 @@ func (g *Generator) generateAddIndex(table string, index Index) string {
 				ddl += fmt.Sprintf(" CONSTRAINT %s", g.escapeSQLName(index.name))
 			}
 
-			ddl += fmt.Sprintf(" %s%s", index.indexType, clusteredOption)
+			ddl += fmt.Sprintf(" %s%s", strings.ToUpper(index.indexType), clusteredOption)
 		}
 		ddl += fmt.Sprintf(" (%s)%s", strings.Join(columns, ", "), optionDefinition)
 		ddl += partition


### PR DESCRIPTION
For the consistency between `ALTER TABLE ... DROP KEY` and `ALTER TABLE ... ADD key`, etc.
