### PR TITLE
psqldef: Parse interval type

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -262,6 +262,11 @@ IntervalExpression:
       AND created_at <= to_timestamp(concat(to_char(current_date, 'YYYY-MM-DD'), ' 23:59:59'), 'YYYY-MM-DD HH24:MI:SS')
       GROUP BY main_type, sub_type, user_id
     );
+IntervalType:
+  desired: |
+    CREATE TABLE public.test (
+      col interval
+    );
 MaterializedViewIndex:
   desired: |
     CREATE TABLE IF NOT EXISTS points (

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -523,7 +523,7 @@ func (p PostgresParser) parseTypeName(node *pgquery.TypeName) (parser.ColumnType
 				columnType.Type = "integer"
 			case "int8":
 				columnType.Type = "bigint"
-			case "varchar": // TODO: use this pattern more, fixing failed tests as well
+			case "varchar", "interval": // TODO: use this pattern more, fixing failed tests as well
 				columnType.Type = typeNames[1]
 			default:
 				return columnType, fmt.Errorf("unhandled type in parseTypeName: %s", typeNames[1])


### PR DESCRIPTION
fixes #334 

I fixed parser for `interval` type.
If there is better way, please let me know.