### PR TITLE
mssqldef: Fixed exporting error when a table has multiple indexes.

### DIFF
--- a/cmd/mssqldef/tests.yml
+++ b/cmd/mssqldef/tests.yml
@@ -28,3 +28,11 @@ TestMssqldefColumnLiteral:
       v_varbinary_max varbinary(max),
       v_ntext ntext
     );
+TestMssqldefMultipleIndex:
+  desired: |
+    CREATE TABLE v (
+      v_integer integer NOT NULL,
+      v_nchar nchar(30)
+    );
+    CREATE NONCLUSTERED INDEX idx1_v ON v (v_integer);
+    CREATE NONCLUSTERED INDEX idx2_v ON v (v_nchar);

--- a/database/mssql/database.go
+++ b/database/mssql/database.go
@@ -186,6 +186,7 @@ func buildDumpTableDDL(table string, columns []column, indexDefs []*indexDef, fo
 			}
 			fmt.Fprint(&queryBuilder, " )")
 		}
+		fmt.Fprintf(&queryBuilder, ";")
 	}
 	return strings.TrimSuffix(queryBuilder.String(), "\n")
 }


### PR DESCRIPTION
fixes #337

Semicolons are inserted at ends of CREATE INDEX statement.