### PR TITLE
[mssqldef] Add semicolon to exported view definition.

### DIFF
--- a/cmd/mssqldef/tests.yml
+++ b/cmd/mssqldef/tests.yml
@@ -133,3 +133,10 @@ DropTableOnNonStandardDefaultSchema:
   output: |
     DROP TABLE [FOO].[v];
   user: "mssqldef_user"
+MultipleView:
+  current: |
+    CREATE VIEW v1 AS SELECT 1 AS N;
+    CREATE VIEW v2 AS SELECT 2 AS N;
+  output: |
+    DROP VIEW [dbo].[v1];
+    DROP VIEW [dbo].[v2];

--- a/database/mssql/database.go
+++ b/database/mssql/database.go
@@ -507,7 +507,7 @@ INNER JOIN sys.sql_modules
 		definition = strings.ReplaceAll(definition, "\n", "")
 		definition = suffixSemicolon.ReplaceAllString(definition, "")
 		definition = spaces.ReplaceAllString(definition, " ")
-		ddls = append(ddls, definition)
+		ddls = append(ddls, definition+";")
 	}
 	return ddls, nil
 }


### PR DESCRIPTION
fix #366