### PR TITLE
MySQL's default index is B-Tree, so if not specified, the comparison is performed as B-Tree

### DIFF
--- a/cmd/mysqldef/mysqldef_test.go
+++ b/cmd/mysqldef/mysqldef_test.go
@@ -592,6 +592,138 @@ func TestMysqldefIndexOption(t *testing.T) {
 	)
 	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD KEY `index_id` (`id`) using BTREE;\n")
 	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  KEY index_id (id) using btree
+		);`,
+	)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  KEY index_id (id)
+		);`,
+	)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	resetTestDatabase()
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL
+		);`,
+	)
+	assertApply(t, createTable)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  KEY index_id (id)
+		);`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD KEY `index_id` (`id`);\n")
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  KEY index_id (id) USING BTREE
+		);`,
+	)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  KEY index_id (id) using btree
+		);`,
+	)
+	assertApplyOutput(t, createTable, nothingModified)
+}
+
+func TestMysqldefMultipleColumnIndexesOption(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  registered_at datetime(6) NOT NULL,
+		  role_type int(1) NOT NULL
+		);`,
+	)
+	assertApply(t, createTable)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  registered_at datetime(6) NOT NULL,
+		  role_type int(1) NOT NULL,
+		  INDEX index_id (registered_at, role_type) USING BTREE
+		);`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD INDEX `index_id` (`registered_at`, `role_type`) using BTREE;\n")
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  registered_at datetime(6) NOT NULL,
+		  role_type int(1) NOT NULL,
+		  INDEX index_id (registered_at, role_type) using btree
+		);`,
+	)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  registered_at datetime(6) NOT NULL,
+		  role_type int(1) NOT NULL,
+		  INDEX index_id (registered_at, role_type)
+		);`,
+	)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	resetTestDatabase()
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  registered_at datetime(6) NOT NULL,
+		  role_type int(1) NOT NULL
+		);`,
+	)
+	assertApply(t, createTable)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  registered_at datetime(6) NOT NULL,
+		  role_type int(1) NOT NULL,
+		  INDEX index_id (registered_at, role_type)
+		);`,
+	)
+	assertApplyOutput(t, createTable, applyPrefix+"ALTER TABLE `users` ADD INDEX `index_id` (`registered_at`, `role_type`);\n")
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  registered_at datetime(6) NOT NULL,
+		  role_type int(1) NOT NULL,
+		  INDEX index_id (registered_at, role_type) USING BTREE
+		);`,
+	)
+	assertApplyOutput(t, createTable, nothingModified)
+
+	createTable = stripHeredoc(`
+		CREATE TABLE users (
+		  id int(11) NOT NULL,
+		  registered_at datetime(6) NOT NULL,
+		  role_type int(1) NOT NULL,
+		  INDEX index_id (registered_at, role_type) using btree
+		);`,
+	)
+	assertApplyOutput(t, createTable, nothingModified)
 }
 
 func TestMysqldefFulltextIndex(t *testing.T) {

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -1728,8 +1728,19 @@ func (g *Generator) areSameIndexes(indexA Index, indexB Index) bool {
 		}
 	}
 
-	for _, optionB := range indexB.options {
-		if optionA := findIndexOptionByName(indexA.options, optionB.optionName); optionA != nil {
+	indexAOptions := indexA.options
+	indexBOptions := indexB.options
+	// Mysql: Default Index B-Tree
+	if g.mode == GeneratorModeMysql {
+		if len(indexAOptions) == 0 {
+			indexAOptions = []IndexOption{{optionName: "using", value: &Value{valueType: ValueTypeStr, raw: []byte("btree"), strVal: "btree"}}}
+		}
+		if len(indexBOptions) == 0 {
+			indexBOptions = []IndexOption{{optionName: "using", value: &Value{valueType: ValueTypeStr, raw: []byte("btree"), strVal: "btree"}}}
+		}
+	}
+	for _, optionB := range indexBOptions {
+		if optionA := findIndexOptionByName(indexAOptions, optionB.optionName); optionA != nil {
 			if !g.areSameValue(optionA.value, optionB.value) {
 				return false
 			}


### PR DESCRIPTION
Now, there is a difference between Index unspecified and USING BTREE.
fixed to set default value when comparing Indexes so that there is no difference.

* RDBMS: MySQL
* Version: -

## --export output
```
CREATE TABLE users (
  id int(11) NOT NULL,
  KEY index_id (id)
);
```

## Input SQL
```
CREATE TABLE users (
  id int(11) NOT NULL,
  KEY index_id (id) USING BTREE
);
```

## Now output

```
ALTER TABLE `users` DROP KEY `index_id` (`id`);
ALTER TABLE `users` ADD KEY `index_id` (`id`) USING BTREE;
```

## This PR output

```
-- Nothing is modified --
```
