### PR TITLE
add CGO_ENABLED=1 explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,11 @@ test-mysqldef:
 	go test -v ./cmd/mysqldef
 
 test-psqldef:
-	go test -v ./cmd/psqldef ./database/postgres
+	if [[ $(GOOS) != windows ]]; then \
+		CGO_ENABLED=1 go test -v ./cmd/psqldef ./database/postgres; \
+	else \
+		go test -v ./cmd/psqldef ./database/postgres; \
+	fi
 
 test-sqlite3def:
 	go test -v ./cmd/sqlite3def


### PR DESCRIPTION
As with [build](https://github.com/k0kubun/sqldef/blob/d8b3375a13ee2106374ff81243b0f6a9e953e02f/Makefile#L26-L28), I explicitly added CGO_ENABLED=1 in test-psqldef as well