### PR TITLE
add postgresql 15 to test matrix

### DIFF
--- a/.github/workflows/sqldef.yml
+++ b/.github/workflows/sqldef.yml
@@ -33,6 +33,8 @@ jobs:
             postgres_version: 13
           - target: psqldef
             postgres_version: 14
+          - target: psqldef
+            postgres_version: 15
       fail-fast: false
     steps:
       - uses: actions/setup-go@v3

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -1245,6 +1245,7 @@ func TestPsqldefBeforeApply(t *testing.T) {
 	// Setup
 	mustExecuteSQL("DROP ROLE IF EXISTS dummy_owner_role;")
 	mustExecuteSQL("CREATE ROLE dummy_owner_role;")
+	mustExecuteSQL("GRANT ALL ON SCHEMA public TO dummy_owner_role;")
 
 	beforeApply := "SET ROLE dummy_owner_role; SET TIME ZONE LOCAL;"
 	createTable := "CREATE TABLE dummy (id int);"


### PR DESCRIPTION
posgtresql v15 was released, so I added to the test matrix.

https://www.postgresql.org/docs/15/release-15.html#id-1.11.6.7.4
From v15, postgres remove PUBLIC creation permission on the public schema as default.
So, I added GRANT ALL to dummy role for test.