### PR TITLE
Escape parameters in unique constraint query for postgres

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -472,6 +472,22 @@ IndexesOnChangedExpressions:
   output: |
     DROP INDEX "public"."function_index";
     CREATE UNIQUE INDEX function_index ON public.test (jsonb_extract_path_text(col, 'foo'));
+EscapeUniqueIndexQuery:
+  current: |
+    CREATE TABLE "userTable" (
+        id uuid NOT NULL,
+        "firstName" text,
+        "lastName" text
+    );
+  desired: |
+    CREATE TABLE "userTable" (
+        id uuid NOT NULL,
+        "firstName" text,
+        "lastName" text
+    );
+    ALTER TABLE "public"."userTable" ADD CONSTRAINT "uq:fullName" UNIQUE ("firstName", "lastName");
+  output: |
+    ALTER TABLE "public"."userTable" ADD CONSTRAINT "uq:fullName" UNIQUE ("firstName", "lastName");
 AddArrayColumn:
   current: |
     CREATE TABLE users (

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -574,7 +574,11 @@ func (d *PostgresDatabase) getUniqueConstraints(tableName string) (map[string]st
 		if err != nil {
 			return nil, err
 		}
-		result[constraintName] = fmt.Sprintf("ALTER TABLE %s ADD CONSTRAINT %s %s", tableName, constraintName, constraintDef)
+
+		result[constraintName] = fmt.Sprintf("ALTER TABLE %s.%s ADD CONSTRAINT %s %s",
+			escapeSQLName(schema), escapeSQLName(table),
+			escapeSQLName(constraintName), constraintDef,
+		)
 	}
 
 	return result, nil


### PR DESCRIPTION
# Issue

`psqldef` fails to export when database has unique index whose name needs escaping.

```
$ psqldef -U postgres work --export
2023/05/11 16:37:49 syntax error at or near ":"
```

In my case, I faced it with the name `uq:_fluent_migrations.name`.

Here is screenshot of the table.

<img width="1448" alt="スクリーンショット 2023-05-11 16 37 19" src="https://github.com/k0kubun/sqldef/assets/312792/b18db4df-1b65-40c5-bc0f-5c8f1b16b5dc">

This is created by Fluent (https://github.com/vapor/fluent) 
which is the most popular web framework for Swift 😄

# Patch

This patch fixes the issue.

I added test case.
It fails on master.

```
=== RUN   TestApply/EscapeUniqueIndexQuery
    testutils.go:121: syntax error at or near ":"

FAIL
FAIL	github.com/k0kubun/sqldef/cmd/psqldef	85.223s
FAIL
```

It success on this patch.