### PR TITLE
[psqldef]Fix Error in Materialized Views with Multiple Indices

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -171,7 +171,9 @@ func (d *PostgresDatabase) materializedViews() ([]string, error) {
 		if err != nil {
 			return ddls, err
 		}
-		ddls = append(ddls, indexDefs...)
+		for _, indexDef := range indexDefs {
+			ddls = append(ddls, fmt.Sprintf("%s;", indexDef))
+		}
 	}
 	return ddls, nil
 }


### PR DESCRIPTION
## ISSUE

There was a bug causing an error when multiple indices existed in a MATERIALIZED VIEW or when multiple MATERIALIZED VIEWs were present.

exmple

schema.sql
```sql
CREATE MATERIALIZED VIEW public.view_users AS SELECT * FROM users;
CREATE INDEX index_name on public.view_users (name);
CREATE UNIQUE INDEX index_age on public.view_users (age);
```

get ddl
```sql
CREATE MATERIALIZED VIEW public.view_users AS SELECT * FROM users;
CREATE INDEX index_name on public.view_users (name)
CREATE UNIQUE INDEX index_age on public.view_users (age)
```

## PATCH

The reason was the absence of a semicolon at the end of the index. This time, we have addressed the issue by adding semicolons and also added test codes.