### PR TITLE
Enhance postgres parser tests by comparing with generic parser results

### DIFF
--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -222,7 +222,8 @@ func (p PostgresParser) parseSelectStmt(stmt *pgquery.SelectStmt) (parser.Select
 		SelectExprs: selectExprs,
 		From: parser.TableExprs{
 			&parser.AliasedTableExpr{
-				Expr: fromTable,
+				Expr:       fromTable,
+				TableHints: []string{},
 			},
 		},
 	}, nil

--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -112,6 +112,7 @@ func (p PostgresParser) parseCreateStmt(stmt *pgquery.CreateStmt) (parser.Statem
 		NewName: tableName,
 		TableSpec: &parser.TableSpec{
 			Columns: columns,
+			Options: map[string]string{},
 		},
 	}, nil
 }

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -1,9 +1,11 @@
 CreateTable:
+  compare_with_generic_parser: true
   sql: |
     CREATE TABLE bigdata (
       data bigint
     );
 CreateTableWithSchema:
+  compare_with_generic_parser: true
   sql: |
     CREATE TABLE public.bigdata (
       data bigint

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -1,60 +1,73 @@
-CreateTable: |
-  CREATE TABLE bigdata (
-    data bigint
-  );
-CreateTableWithSchema: |
-  CREATE TABLE public.bigdata (
-    data bigint
-  );
-CreateTableWithNotNull: |
-  CREATE TABLE public.airline_confirmation (
-    airline_id bigint,
-    code character varying(512),
-    booking_id bigint NOT NULL
-  );
-CreateView: |
-  create view hoge_view as
-  select amount from hoge;
-CreateViewWithCast: |
-  create view hoge_view as
-  select amount::numeric(10,2) from hoge;
-CreateViewWithFullColumn: |
-  CREATE VIEW public.hoge_view
-  AS SELECT (hoge.amount)::numeric(10,2) AS amount_num FROM hoge;
-CreateViewWithCaseWhen: |
-  create view hoge_view as
-  select
-    -- pattern 1
-    amount::numeric(10,2) as amount_num1,
-    -- pattern 2
-    (
-      jsonb_extract_path_text(payload, 'amount')
-    )::numeric(10,2) as amount_num2,
-    -- pattern 3
-    (
-      case hoge_type
-        when 'hoge' then jsonb_extract_path_text(payload, 'hoge', 'amount')
-      end
-    )::numeric(10,2) as amount_num3,
-    -- pattern 4
-    (
-      to_timestamp(
-        jsonb_extract_path_text(payload, 'created')::bigint
-      )
-    ) as created,
-    -- pattern 5
-    (
-      cast(
+CreateTable:
+  sql: |
+    CREATE TABLE bigdata (
+      data bigint
+    );
+CreateTableWithSchema:
+  sql: |
+    CREATE TABLE public.bigdata (
+      data bigint
+    );
+CreateTableWithNotNull:
+  sql: |
+    CREATE TABLE public.airline_confirmation (
+      airline_id bigint,
+      code character varying(512),
+      booking_id bigint NOT NULL
+    );
+CreateView:
+  sql: |
+    create view hoge_view as
+    select amount from hoge;
+CreateViewWithCast:
+  sql: |
+    create view hoge_view as
+    select amount::numeric(10,2) from hoge;
+CreateViewWithFullColumn:
+  sql: |
+    CREATE VIEW public.hoge_view
+    AS SELECT (hoge.amount)::numeric(10,2) AS amount_num FROM hoge;
+CreateViewWithCaseWhen:
+  sql: |
+    create view hoge_view as
+    select
+      -- pattern 1
+      amount::numeric(10,2) as amount_num1,
+      -- pattern 2
+      (
+        jsonb_extract_path_text(payload, 'amount')
+      )::numeric(10,2) as amount_num2,
+      -- pattern 3
+      (
+        case hoge_type
+          when 'hoge' then jsonb_extract_path_text(payload, 'hoge', 'amount')
+        end
+      )::numeric(10,2) as amount_num3,
+      -- pattern 4
+      (
         to_timestamp(
           jsonb_extract_path_text(payload, 'created')::bigint
-        ) as date
-      )
-    ) as created_date
-  from hoge;
-CreateIndexWithFuncCall: |
-  CREATE UNIQUE INDEX airline_confirmation_code_unique_idx
-  ON public.airline_confirmation
-  USING btree (airline_id, booking_id, lower((code)::text))
-  WHERE ((code IS NOT NULL) AND (airline_id IS NOT NULL));
-CreateIndexConcurrently: |
-  CREATE INDEX CONCURRENTLY username on users (name);
+        )
+      ) as created,
+      -- pattern 5
+      (
+        cast(
+          to_timestamp(
+            jsonb_extract_path_text(payload, 'created')::bigint
+          ) as date
+        )
+      ) as created_date
+    from hoge;
+CreateIndex:
+  compare_with_generic_parser: true
+  sql: |
+    CREATE INDEX username on users using btree (name asc);
+CreateIndexWithFuncCall:
+  sql: |
+    CREATE UNIQUE INDEX airline_confirmation_code_unique_idx
+    ON public.airline_confirmation
+    USING btree (airline_id, booking_id, lower((code)::text))
+    WHERE ((code IS NOT NULL) AND (airline_id IS NOT NULL));
+CreateIndexConcurrently:
+  sql: |
+    CREATE INDEX CONCURRENTLY username on users (name);

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -18,10 +18,12 @@ CreateTableWithNotNull:
       booking_id bigint NOT NULL
     );
 CreateView:
+  compare_with_generic_parser: true
   sql: |
     create view hoge_view as
     select amount from hoge;
 CreateViewWithCast:
+  compare_with_generic_parser: true
   sql: |
     create view hoge_view as
     select amount::numeric(10,2) from hoge;

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/microsoft/go-mssqldb v0.21.0
 	github.com/pganalyze/pg_query_go/v2 v2.2.0
+	github.com/stretchr/testify v1.8.3
 	golang.org/x/term v0.7.0
 	gopkg.in/yaml.v2 v2.4.0
 	modernc.org/sqlite v1.22.1
@@ -39,7 +40,10 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	google.golang.org/protobuf v1.23.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.1/go.mod h1:gLa1CL2RNE4s7M
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/AzureAD/microsoft-authentication-library-for-go v0.8.1/go.mod h1:4qFor3D/HDsvBME35Xy9rwW9DecL+M2sNw1ybjPtwA0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
@@ -72,6 +73,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
+github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -131,6 +134,8 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 lukechampine.com/uint128 v1.2.0 h1:mBi/5l91vocEN8otkC5bDLhi2KdCticRiwbdB0O+rjI=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/cc/v3 v3.40.0 h1:P3g79IUS/93SYhtoeaHW+kRCIrYaxJ27MFPv+7kaTOw=


### PR DESCRIPTION
In this pull request, we have improved the postgres parser tests by comparing the parsing results with those of the generic parser.

Previously, the tests only checked if the parsing process completed without errors, which made it difficult to verify if the parsing was done correctly. 

To resolve this issue, I suggest comparing the postgres parser test results with the generic parser results to ensure they are identical. However, due to the complexity of making every test case match the generic parser's results, the comparison is done only for cases with the `compare_with_generic_parser` option enabled.

To perform the struct comparisons, I used the [stretchr/testify](https://github.com/stretchr/testify) library, which provided the most desirable behavior after testing other libraries such as [google/go-cmp](https://github.com/google/go-cmp) and [go-test/deep](https://github.com/go-test/deep). If the test fails, the output is as followings:

```
    parser_test.go:38:
                Error Trace:    /Users/hokaccha/local/src/github.com/k0kubun/sqldef/database/postgres/parser_test.go:38
                Error:          Not equal:
                                expected: []database.DDLStatement{database.DDLStatement{DDL:"CREATE TABLE public.bigdata (\n  data bigint\n)",
Statement:(*parser.DDL)(0x140000ecd20)}}
                                actual  : []database.DDLStatement{database.DDLStatement{DDL:"CREATE TABLE public.bigdata (\n  data bigint\n)",
Statement:(*parser.DDL)(0x140000ecb40)}}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -72,4 +72,3 @@
                                     Checks: ([]*parser.CheckDefinition) <nil>,
                                -    Options: (map[string]string) {
                                -    }
                                +    Options: (map[string]string) <nil>
                                    }),
                Test:           TestParse/CreateTableWithSchema
```