### PR TITLE
Support alter table constraint for postgres parser

### DIFF
--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -79,3 +79,7 @@ AlterTableUnique:
   compare_with_generic_parser: true
   sql: |
     ALTER TABLE users ADD CONSTRAINT username UNIQUE (name, age);
+AlterTableAddForeignKey:
+  compare_with_generic_parser: true
+  sql: |
+    ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL ON UPDATE RESTRICT;

--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -75,3 +75,7 @@ CreateIndexWithFuncCall:
 CreateIndexConcurrently:
   sql: |
     CREATE INDEX CONCURRENTLY username on users (name);
+AlterTableUnique:
+  compare_with_generic_parser: true
+  sql: |
+    ALTER TABLE users ADD CONSTRAINT username UNIQUE (name, age);


### PR DESCRIPTION
Added support for constraint syntax to add unique index and foreign key in ALTER TABLE. The following SQL can now be parsed by the postgres parser.

```sql
ALTER TABLE users ADD CONSTRAINT username UNIQUE (name, age);
ALTER TABLE ONLY public.posts ADD CONSTRAINT posts_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL ON UPDATE RESTRICT;
```