### PR TITLE
Fix errors caused by updating to pgquery v4

### DIFF
--- a/database/postgres/parser.go
+++ b/database/postgres/parser.go
@@ -514,7 +514,7 @@ func (p PostgresParser) parseConstraint(constraint *pgquery.Constraint, tableNam
 		cols := make([]parser.IndexColumn, len(constraint.Keys))
 		for i, key := range constraint.Keys {
 			cols[i] = parser.IndexColumn{
-				Column:    parser.NewColIdent(key.Node.(*pgquery.Node_String_).String_.Str),
+				Column:    parser.NewColIdent(key.Node.(*pgquery.Node_String_).String_.Sval),
 				Direction: "asc",
 			}
 		}
@@ -536,12 +536,12 @@ func (p PostgresParser) parseConstraint(constraint *pgquery.Constraint, tableNam
 	case pgquery.ConstrType_CONSTR_FOREIGN:
 		idxCols := make([]parser.ColIdent, len(constraint.FkAttrs))
 		for i, fkAttr := range constraint.FkAttrs {
-			v := fkAttr.Node.(*pgquery.Node_String_).String_.Str
+			v := fkAttr.Node.(*pgquery.Node_String_).String_.Sval
 			idxCols[i] = parser.NewColIdent(v)
 		}
 		refCols := make([]parser.ColIdent, len(constraint.PkAttrs))
 		for i, pkAttr := range constraint.PkAttrs {
-			v := pkAttr.Node.(*pgquery.Node_String_).String_.Str
+			v := pkAttr.Node.(*pgquery.Node_String_).String_.Sval
 			refCols[i] = parser.NewColIdent(v)
 		}
 


### PR DESCRIPTION
The changes on https://github.com/k0kubun/sqldef/pull/404 were not compatible with the type updated on https://github.com/k0kubun/sqldef/pull/406.