### PR TITLE
Support `select *` for postgres parser

### DIFF
--- a/database/postgres/tests.yml
+++ b/database/postgres/tests.yml
@@ -66,6 +66,11 @@ CreateViewWithCaseWhen:
 CreateViewWithoutFrom:
   sql: |
     create view v as select 10 as n;
+CreateViewWithStarExpr:
+  compare_with_generic_parser: true
+  sql: |
+    create view hoge_view as
+    select t.* from hoge t;
 CreateIndex:
   compare_with_generic_parser: true
   sql: |


### PR DESCRIPTION
This PR resolves the error in https://github.com/k0kubun/sqldef/issues/397. However, there is a problem as follows.

```sql
# schema.sql
CREATE TABLE public.test_table (
  "col1" numeric,
  "col2" numeric
);
CREATE VIEW public.test_view AS SELECT t.* FROM test_table t;
```

```
$ go run ./cmd/psqldef -h localhost -U postgres sandbox < schema.sql
-- Apply --
CREATE TABLE public.test_table (
  "col1" numeric,
  "col2" numeric
);
CREATE VIEW public.test_view AS SELECT t.* FROM test_table t;
```

```
# Run the same command again
$ go run ./cmd/psqldef -h localhost -U postgres sandbox < schema.sql
-- Apply --
CREATE OR REPLACE VIEW "public"."test_view" AS select t.* from test_table as t;
```

No matter how many times `psqldef` is executed, `CREATE OR REPLACE VIEW` is executed. It seems that the cause is that when `select *` is specified, the query is saved as a query with expanded columns.

```
$ psql -h localhost -U postgres sandbox -c "SELECT definition FROM pg_views WHERE viewname = 'test_view'"
      definition
-----------------------
  SELECT t.col1,      +
     t.col2           +
    FROM test_table t;
(1 row)
```

Therefore, it becomes as follows:

- `currentDDL`: `SELECT t.col1, t.col2`
- `desiredDDL`: `SELECT t.*`

As a result, the comparison fails. This seems to be the same not only for postgres but also for mysql. I have confirmed that the same phenomenon occurs with `mysqldef`.

To solve this problem, we need a process to expand `*` when parsing `desiredDDL`. This is not impossible, but it seems to take time. Another option is to have sqldef output an error that it does not support `*` and exit until this problem is solved.

@k0kubun Which do you think is better?