### PR TITLE
Fix the description of `enable-drop-table` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Application Options:
       --file=sql_file               Read schema SQL from the file, rather than stdin (default: -)
       --dry-run                     Don't run DDLs but just show them
       --export                      Just dump the current schema to stdout
-      --enable-drop-table           Enable destructive changes such as DROP (skip only table drops)
+      --enable-drop-table           Enable destructive changes such as DROP (enable only table drops)
       --skip-view                   Skip managing views (temporary feature, to be removed later)
       --before-apply=               Execute the given string before applying the regular DDLs
       --config=                     YAML file to specify: target_tables
@@ -128,7 +128,7 @@ Application Options:
   -f, --file=filename        Read schema SQL from the file, rather than stdin (default: -)
       --dry-run              Don't run DDLs but just show them
       --export               Just dump the current schema to stdout
-      --enable-drop-table    Enable destructive changes such as DROP (skip only table drops)
+      --enable-drop-table    Enable destructive changes such as DROP (enable only table drops)
       --before-apply=        Execute the given string before applying the regular DDLs
       --config=              YAML file to specify: target_tables
       --help                 Show this help
@@ -215,7 +215,7 @@ Application Options:
   -f, --file=filename     Read schema SQL from the file, rather than stdin (default: -)
       --dry-run           Don't run DDLs but just show them
       --export            Just dump the current schema to stdout
-      --enable-drop-table Enable destructive changes such as DROP (skip only table drops)
+      --enable-drop-table Enable destructive changes such as DROP (enable only table drops)
       --config=           YAML file to specify: target_tables
       --help              Show this help
       --version
@@ -236,7 +236,7 @@ Application Options:
       --file=sql_file        Read schema SQL from the file, rather than stdin (default: -)
       --dry-run              Don't run DDLs but just show them
       --export               Just dump the current schema to stdout
-      --enable-drop-table    Enable destructive changes such as DROP (skip only table drops)
+      --enable-drop-table    Enable destructive changes such as DROP (enable only table drops)
       --help                 Show this help
       --version              Show this version
 ```

--- a/cmd/mssqldef/mssqldef.go
+++ b/cmd/mssqldef/mssqldef.go
@@ -30,7 +30,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		File            []string `long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
 		DryRun          bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export          bool     `long:"export" description:"Just dump the current schema to stdout"`
-		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (skip only table drops)"`
+		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
 		Help            bool     `long:"help" description:"Show this help"`
 		Version         bool     `long:"version" description:"Show this version"`
 	}

--- a/cmd/mysqldef/mysqldef.go
+++ b/cmd/mysqldef/mysqldef.go
@@ -36,7 +36,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		File                  []string `long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"sql_file" default:"-"`
 		DryRun                bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export                bool     `long:"export" description:"Just dump the current schema to stdout"`
-		EnableDropTable       bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (skip only table drops)"`
+		EnableDropTable       bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
 		SkipView              bool     `long:"skip-view" description:"Skip managing views (temporary feature, to be removed later)"`
 		BeforeApply           string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
 		Config                string   `long:"config" description:"YAML file to specify: target_tables, skip_tables"`

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -31,7 +31,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		File            []string `short:"f" long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"filename" default:"-"`
 		DryRun          bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export          bool     `long:"export" description:"Just dump the current schema to stdout"`
-		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (skip only table drops)"`
+		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
 		BeforeApply     string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
 		Config          string   `long:"config" description:"YAML file to specify: target_tables, skip_tables"`
 		Help            bool     `long:"help" description:"Show this help"`

--- a/cmd/sqlite3def/sqlite3def.go
+++ b/cmd/sqlite3def/sqlite3def.go
@@ -24,7 +24,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		File            []string `short:"f" long:"file" description:"Read schema SQL from the file, rather than stdin" value-name:"filename" default:"-"`
 		DryRun          bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export          bool     `long:"export" description:"Just dump the current schema to stdout"`
-		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (skip only table drops)"`
+		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
 		Config          string   `long:"config" description:"YAML file to specify: target_tables, skip_tables"`
 		Help            bool     `long:"help" description:"Show this help"`
 		Version         bool     `long:"version" description:"Show this version"`


### PR DESCRIPTION
I'm sorry if I misunderstood something, but this option enables `DROP`, so `skip` isn't the correct description I think.