### PR TITLE
Migrate from deprecated ioutil to compatible functions

### DIFF
--- a/cmd/testutils/testutils.go
+++ b/cmd/testutils/testutils.go
@@ -3,8 +3,8 @@ package testutils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -35,7 +35,7 @@ func ReadTests(pattern string) (map[string]TestCase, error) {
 	for _, file := range files {
 		var tests map[string]*TestCase
 
-		buf, err := ioutil.ReadFile(file)
+		buf, err := os.ReadFile(file)
 		if err != nil {
 			return nil, err
 		}

--- a/database/database.go
+++ b/database/database.go
@@ -4,8 +4,8 @@ package database
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -83,7 +83,7 @@ func ParseGeneratorConfig(configFile string) GeneratorConfig {
 		return GeneratorConfig{}
 	}
 
-	buf, err := ioutil.ReadFile(configFile)
+	buf, err := os.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/database/mssql/parser_test.go
+++ b/database/mssql/parser_test.go
@@ -1,7 +1,7 @@
 package mssql
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -25,7 +25,7 @@ func TestParse(t *testing.T) {
 }
 
 func readTests(file string) (map[string]string, error) {
-	buf, err := ioutil.ReadFile(file)
+	buf, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/database/mysql/database.go
+++ b/database/mysql/database.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	driver "github.com/go-sql-driver/mysql"
@@ -174,7 +174,7 @@ func mysqlBuildDSN(config database.Config) string {
 
 func registerTLSConfig(pemPath string) error {
 	rootCertPool := x509.NewCertPool()
-	pem, err := ioutil.ReadFile(pemPath)
+	pem, err := os.ReadFile(pemPath)
 	if err != nil {
 		return err
 	}

--- a/database/postgres/parser_test.go
+++ b/database/postgres/parser_test.go
@@ -1,7 +1,7 @@
 package postgres
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/k0kubun/sqldef/database"
@@ -46,7 +46,7 @@ type TestCase struct {
 }
 
 func readTests(file string) (map[string]TestCase, error) {
-	buf, err := ioutil.ReadFile(file)
+	buf, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/sqldef.go
+++ b/sqldef.go
@@ -2,7 +2,7 @@ package sqldef
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -118,9 +118,9 @@ func ReadFile(filepath string) (string, error) {
 			return "", fmt.Errorf("stdin is not piped")
 		}
 
-		buf, err = ioutil.ReadAll(os.Stdin)
+		buf, err = io.ReadAll(os.Stdin)
 	} else {
-		buf, err = ioutil.ReadFile(filepath)
+		buf, err = os.ReadFile(filepath)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Replaced the `ioutil` package with compatible functions as `ioutil` package is deprecated.

https://pkg.go.dev/io/ioutil

> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code.

