### PR TITLE
Fix missing SET type members

### DIFF
--- a/cmd/mysqldef/tests.yml
+++ b/cmd/mysqldef/tests.yml
@@ -327,6 +327,16 @@ TableComment:
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='都道府県マスター';
   output: |
     ALTER TABLE `prefecture` COMMENT = '都道府県マスター';
+AlterTableAddSetTypeColumn:
+  current: |
+    CREATE TABLE alarm (id BIGINT PRIMARY KEY);
+  desired: |
+    CREATE TABLE alarm (
+      id BIGINT PRIMARY KEY,
+      dayOfWeek SET('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun') NOT NULL
+    );
+  output: |
+    ALTER TABLE `alarm` ADD COLUMN `dayOfWeek` set('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun') NOT NULL AFTER `id`;
 UUIDToBin:
   desired: |
     CREATE TABLE users (

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -993,7 +993,7 @@ func generateDataType(column Column) string {
 		}
 	} else {
 		switch column.typeName {
-		case "enum":
+		case "enum", "set":
 			return fmt.Sprintf("%s(%s)%s", column.typeName, strings.Join(column.enumValues, ", "), suffix)
 		default:
 			return fmt.Sprintf("%s%s", column.typeName, suffix)


### PR DESCRIPTION
In the current version of sqldef, adding a column of SET type results in an ALTER TABLE statement with empty members. This PR fixes that issue.

## Inputs

### current

```sql
CREATE TABLE alarm (id BIGINT PRIMARY KEY);
```

### desired

```sql
CREATE TABLE alarm (
  id BIGINT PRIMARY KEY,
  dayOfWeek SET('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun') NOT NULL
);
```

## Expected

```sql
ALTER TABLE `alarm` ADD COLUMN `dayOfWeek` set('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun') NOT NULL AFTER `id`;
```

## Actural

```sql
ALTER TABLE `alarm` ADD COLUMN `dayOfWeek` set NOT NULL AFTER `id`;
```