### PR TITLE
Add support DATETIME fractional seconds part

### DIFF
--- a/cmd/mysqldef/tests.yml
+++ b/cmd/mysqldef/tests.yml
@@ -531,3 +531,16 @@ RemoveDefaultExpression:
   output: |
     ALTER TABLE `users` CHANGE COLUMN `friend_ids` `friend_ids` json;
   min_version: '8.0'
+AlterTableColumnFractionalSecondsPart:
+  current: |
+    CREATE TABLE users (
+      id bigint(20) PRIMARY KEY,
+      created_at datetime NOT NULL
+    );
+  desired: |
+    CREATE TABLE users (
+      id bigint(20) PRIMARY KEY,
+      created_at datetime(3) NOT NULL
+    );
+  output: |
+    ALTER TABLE `users` CHANGE COLUMN `created_at` `created_at` datetime(3) NOT NULL;

--- a/parser/ast.go
+++ b/parser/ast.go
@@ -733,10 +733,11 @@ type ColumnType struct {
 	Array         BoolVal
 
 	// Numeric field options
-	Length   *SQLVal
-	Unsigned BoolVal
-	Zerofill BoolVal
-	Scale    *SQLVal
+	Length       *SQLVal
+	Unsigned     BoolVal
+	Zerofill     BoolVal
+	Scale        *SQLVal
+	DisplayWidth *SQLVal
 
 	// Text field options
 	Charset string

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6481,7 +6481,7 @@ yydefault:
 //line parser.y:1734
 		{
 			yyVAL.columnType = yyDollar[1].columnType
-			yyVAL.columnType.Length = yyDollar[2].optVal
+			yyVAL.columnType.DisplayWidth = yyDollar[2].optVal
 		}
 	case 264:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1733,7 +1733,7 @@ numeric_type:
   int_type length_opt
   {
     $$ = $1
-    $$.Length = $2
+    $$.DisplayWidth = $2
   }
 | decimal_type
   {

--- a/schema/ast.go
+++ b/schema/ast.go
@@ -64,6 +64,7 @@ type Column struct {
 	sridDef       *SridDefinition
 	length        *Value
 	scale         *Value
+	displayWidth  *Value
 	check         *CheckDefinition
 	charset       string
 	collate       string

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -1006,7 +1006,9 @@ func generateDataType(column Column) string {
 		suffix += "[]"
 	}
 
-	if column.length != nil {
+	if column.displayWidth != nil {
+		return fmt.Sprintf("%s(%s)%s", column.typeName, string(column.displayWidth.raw), suffix)
+	} else if column.length != nil {
 		if column.scale != nil {
 			return fmt.Sprintf("%s(%s, %s)%s", column.typeName, string(column.length.raw), string(column.scale.raw), suffix)
 		} else {

--- a/schema/generator.go
+++ b/schema/generator.go
@@ -1594,12 +1594,31 @@ func (g *Generator) areSameGenerated(generatedA, generatedB *Generated) bool {
 }
 
 func (g *Generator) haveSameDataType(current Column, desired Column) bool {
-	return g.normalizeDataType(current.typeName) == g.normalizeDataType(desired.typeName) &&
-		reflect.DeepEqual(current.enumValues, desired.enumValues) &&
-		(current.length == nil || desired.length == nil || current.length.intVal == desired.length.intVal) && // detect change column only when both are set explicitly. TODO: maybe `current.length == nil` case needs another care
-		(current.scale == nil || desired.scale == nil || current.scale.intVal == desired.scale.intVal) &&
-		(current.array == desired.array) && (current.timezone == desired.timezone)
-	// TODO: scale
+	if g.normalizeDataType(current.typeName) != g.normalizeDataType(desired.typeName) {
+		return false
+	}
+	if !reflect.DeepEqual(current.enumValues, desired.enumValues) {
+		return false
+	}
+	if current.length == nil && desired.length != nil || current.length != nil && desired.length == nil {
+		return false
+	}
+	if current.length != nil && desired.length != nil && current.length.intVal != desired.length.intVal {
+		return false
+	}
+	if current.scale == nil && (desired.scale != nil && desired.scale.intVal != 0) || (current.scale != nil && current.scale.intVal != 0) && desired.scale == nil {
+		return false
+	}
+	if current.scale != nil && desired.scale != nil && current.scale.intVal != desired.scale.intVal {
+		return false
+	}
+	if current.array != desired.array {
+		return false
+	}
+	if current.timezone != desired.timezone {
+		return false
+	}
+	return true
 }
 
 func areSameCheckDefinition(checkA *CheckDefinition, checkB *CheckDefinition) bool {

--- a/schema/parser.go
+++ b/schema/parser.go
@@ -111,6 +111,7 @@ func parseTable(mode GeneratorMode, stmt *parser.DDL, defaultSchema string) (Tab
 			sridDef:       parseSridDefinition(parsedCol.Type.Srid),
 			length:        parseValue(parsedCol.Type.Length),
 			scale:         parseValue(parsedCol.Type.Scale),
+			displayWidth:  parseValue(parsedCol.Type.DisplayWidth),
 			charset:       parsedCol.Type.Charset,
 			collate:       normalizeCollate(parsedCol.Type.Collate, *stmt.TableSpec),
 			timezone:      castBool(parsedCol.Type.Timezone),


### PR DESCRIPTION
In the current version of sqldef, changing the column type from DATETIME to DATETIME(3) does not produce an ALTER TABLE statement. This PR fixes this comparison.

## Inputs

### current

```sql
CREATE TABLE users (
  id bigint(20) PRIMARY KEY,
  created_at datetime NOT NULL
);
```

### desired

```sql
CREATE TABLE users (
  id bigint(20) PRIMARY KEY,
  created_at datetime(3) NOT NULL
);
```

## Expected

```sql
ALTER TABLE `users` CHANGE COLUMN `created_at` `created_at` datetime(3) NOT NULL;
```

## Actural

```sql
```