### PR TITLE
psqldef: Support PGSSLCERT & PGSSLKEY

### DIFF
--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -812,6 +812,14 @@ func postgresBuildDSN(config database.Config) string {
 		options = append(options, fmt.Sprintf("sslrootcert=%s", sslrootcert))
 	}
 
+	if sslcert, ok := os.LookupEnv("PGSSLCERT"); ok { // TODO: have this in database.Config, or standardize config with DSN?
+		options = append(options, fmt.Sprintf("sslcert=%s", sslcert))
+	}
+
+	if sslkey, ok := os.LookupEnv("PGSSLKEY"); ok { // TODO: have this in database.Config, or standardize config with DSN?
+		options = append(options, fmt.Sprintf("sslkey=%s", sslkey))
+	}
+
 	// `QueryEscape` instead of `PathEscape` so that colon can be escaped.
 	return fmt.Sprintf("postgres://%s:%s@%s/%s?%s", url.QueryEscape(user), url.QueryEscape(password), host, database, strings.Join(options, "&"))
 }


### PR DESCRIPTION
I salute a great tool.

## Similar PR

https://github.com/k0kubun/sqldef/pull/130

## Why I create this PR

Execution of `psqldef` failed because `sslcert` and `sslkey` were not set correctly.

```bash
$ psqldef -U username -W password -h 127.0.0.1 -p 26257 -f schema.sql sample
2023/09/18 14:44:28 Error on DumpDDLs: dial tcp 127.0.0.1:26257: connect: connection refused
```

## What I do in this PR

Change to evaluate PGSSLCERT and PGSSLKEY.
This will allow sslcert and sslkey to be set.

## Reference

ssl_cert: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLCERT
ssl_key: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLKEY

ENV and option mapping: https://www.postgresql.org/docs/current/libpq-envars.html#LIBPQ-ENVARS