### PR TITLE
add --skip-view option to psqldef

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Application Options:
       --dry-run              Don't run DDLs but just show them
       --export               Just dump the current schema to stdout
       --enable-drop-table    Enable destructive changes such as DROP (enable only table drops)
+      --skip-view            Skip managing views/materialized views
       --before-apply=        Execute the given string before applying the regular DDLs
       --config=              YAML file to specify: target_tables
       --help                 Show this help

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -32,6 +32,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		DryRun          bool     `long:"dry-run" description:"Don't run DDLs but just show them"`
 		Export          bool     `long:"export" description:"Just dump the current schema to stdout"`
 		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
+		SkipView        bool     `long:"skip-view" description:"Skip managing views/materialized views"`
 		BeforeApply     string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
 		Config          string   `long:"config" description:"YAML file to specify: target_tables, skip_tables"`
 		Help            bool     `long:"help" description:"Show this help"`
@@ -110,6 +111,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		Password: password,
 		Host:     opts.Host,
 		Port:     int(opts.Port),
+		SkipView: opts.SkipView,
 	}
 	if _, err := os.Stat(config.Host); !os.IsNotExist(err) {
 		config.Socket = config.Host

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -1309,6 +1309,21 @@ func TestPsqldefExportCompositePrimaryKey(t *testing.T) {
 	))
 }
 
+func TestPsqldefSkipView(t *testing.T) {
+	resetTestDatabase()
+
+	createTable := "CREATE TABLE users (id bigint);\n"
+	createView := "CREATE VIEW user_views AS SELECT id from users;\n"
+	createMaterializedView := "CREATE MATERIALIZED VIEW user_materialized_views AS SELECT id from users;\n"
+
+	mustExecuteSQL(createTable+createView+createMaterializedView)
+
+	writeFile("schema.sql", createTable)
+
+	output := assertedExecute(t, "./psqldef", "-Upostgres", databaseName, "--skip-view", "-f", "schema.sql")
+	assertEquals(t, output, nothingModified)
+}
+
 func TestPsqldefBeforeApply(t *testing.T) {
 	resetTestDatabase()
 

--- a/database/database.go
+++ b/database/database.go
@@ -18,10 +18,10 @@ type Config struct {
 	Host     string
 	Port     int
 	Socket   string
+	SkipView bool
 
 	// Only MySQL
 	MySQLEnableCleartextPlugin bool
-	SkipView                   bool
 	SslMode                    string
 	SslCa                      string
 }

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -107,6 +107,10 @@ var (
 )
 
 func (d *PostgresDatabase) views() ([]string, error) {
+	if d.config.SkipView {
+		return []string{}, nil
+	}
+
 	rows, err := d.db.Query(`
 		select n.nspname as table_schema, c.relname as table_name, pg_get_viewdef(c.oid) as definition
 		from pg_catalog.pg_class c inner join pg_catalog.pg_namespace n on c.relnamespace = n.oid
@@ -139,6 +143,10 @@ func (d *PostgresDatabase) views() ([]string, error) {
 }
 
 func (d *PostgresDatabase) materializedViews() ([]string, error) {
+	if d.config.SkipView {
+		return []string{}, nil
+	}
+
 	rows, err := d.db.Query(`
 		select n.nspname as schemaname, c.relname as matviewname, pg_get_viewdef(c.oid) as definition
 		from pg_catalog.pg_class c inner join pg_catalog.pg_namespace n on c.relnamespace = n.oid


### PR DESCRIPTION
I just add `psqldef --skip-view` allong w/ #454 discussion, and confirmed this can skip parsing views including both #454 and #455 cases.

This patch mostly traces #214 implementation.
Trick or treat!