### PR TITLE
[psqldef] Add --skip-extension option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Application Options:
       --export               Just dump the current schema to stdout
       --enable-drop-table    Enable destructive changes such as DROP (enable only table drops)
       --skip-view            Skip managing views/materialized views
+      --skip-extension       Skip managing extensions
       --before-apply=        Execute the given string before applying the regular DDLs
       --config=              YAML file to specify: target_tables
       --help                 Show this help

--- a/cmd/psqldef/psqldef.go
+++ b/cmd/psqldef/psqldef.go
@@ -33,6 +33,7 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 		Export          bool     `long:"export" description:"Just dump the current schema to stdout"`
 		EnableDropTable bool     `long:"enable-drop-table" description:"Enable destructive changes such as DROP (enable only table drops)"`
 		SkipView        bool     `long:"skip-view" description:"Skip managing views/materialized views"`
+		SkipExtension   bool     `long:"skip-extension" description:"Skip managing extensions"`
 		BeforeApply     string   `long:"before-apply" description:"Execute the given string before applying the regular DDLs"`
 		Config          string   `long:"config" description:"YAML file to specify: target_tables, skip_tables"`
 		Help            bool     `long:"help" description:"Show this help"`
@@ -106,12 +107,13 @@ func parseOptions(args []string) (database.Config, *sqldef.Options) {
 	}
 
 	config := database.Config{
-		DbName:   databaseName,
-		User:     opts.User,
-		Password: password,
-		Host:     opts.Host,
-		Port:     int(opts.Port),
-		SkipView: opts.SkipView,
+		DbName:        databaseName,
+		User:          opts.User,
+		Password:      password,
+		Host:          opts.Host,
+		Port:          int(opts.Port),
+		SkipView:      opts.SkipView,
+		SkipExtension: opts.SkipExtension,
 	}
 	if _, err := os.Stat(config.Host); !os.IsNotExist(err) {
 		config.Socket = config.Host

--- a/cmd/psqldef/psqldef_test.go
+++ b/cmd/psqldef/psqldef_test.go
@@ -1316,11 +1316,24 @@ func TestPsqldefSkipView(t *testing.T) {
 	createView := "CREATE VIEW user_views AS SELECT id from users;\n"
 	createMaterializedView := "CREATE MATERIALIZED VIEW user_materialized_views AS SELECT id from users;\n"
 
-	mustExecuteSQL(createTable+createView+createMaterializedView)
+	mustExecuteSQL(createTable + createView + createMaterializedView)
 
 	writeFile("schema.sql", createTable)
 
 	output := assertedExecute(t, "./psqldef", "-Upostgres", databaseName, "--skip-view", "-f", "schema.sql")
+	assertEquals(t, output, nothingModified)
+}
+
+func TestPsqldefSkipExtension(t *testing.T) {
+	resetTestDatabase()
+
+	createExtension := "CREATE EXTENSION pgcrypto;\n"
+
+	mustExecuteSQL(createExtension)
+
+	writeFile("schema.sql", "")
+
+	output := assertedExecute(t, "./psqldef", "-Upostgres", databaseName, "--skip-extension", "-f", "schema.sql")
 	assertEquals(t, output, nothingModified)
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Config struct {
-	DbName   string
-	User     string
-	Password string
-	Host     string
-	Port     int
-	Socket   string
-	SkipView bool
+	DbName        string
+	User          string
+	Password      string
+	Host          string
+	Port          int
+	Socket        string
+	SkipView      bool
+	SkipExtension bool
 
 	// Only MySQL
 	MySQLEnableCleartextPlugin bool

--- a/database/postgres/database.go
+++ b/database/postgres/database.go
@@ -186,6 +186,10 @@ func (d *PostgresDatabase) materializedViews() ([]string, error) {
 }
 
 func (d *PostgresDatabase) extensions() ([]string, error) {
+	if d.config.SkipExtension {
+		return []string{}, nil
+	}
+
 	rows, err := d.db.Query(`
 		SELECT extname FROM pg_extension
 		WHERE extname != 'plpgsql';


### PR DESCRIPTION
I have added the `--skip-extension` option to psqldef because there are cases where we don't want to manage extensions with sqldef.


@k0kubun Please review. If you approve, I will merge and release it myself.