### PR TITLE
[DO NOT MERGE] fix a failing test CollateOnColumn

### DIFF
--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -1511,6 +1511,6 @@ CollateOnColumn:
         name varchar(255) not null
     );
     create view user_view as
-    select users.id,
-          (users.name collate "ja-JP-x-icu") as name
+    select id,
+          (name COLLATE "ja-JP-x-icu") as name
     from users;


### PR DESCRIPTION
There's a failing test case on my environment (macOS, PostgreSQL server 17.5). I'm not sure why it fails, but the patch fixes the problem:

```
$ go test ./cmd/psqldef -run=TestApply/CollateOnColumn
--- FAIL: TestApply (0.66s)
    --- FAIL: TestApply/CollateOnColumn (0.64s)
        testutils.go:127: expected nothing is modified, but got:
            ```
            DROP VIEW "public"."user_view";
            CREATE VIEW "public"."user_view" AS select users.id, (users.name collate ja-JP-x-icu) as name from users;
            ```
FAIL
FAIL	github.com/sqldef/sqldef/v2/cmd/psqldef	2.810s
FAIL
```

However, I rather think it is the schema compeator that should be fixed, by normalizing the attributes before comparison. 

So this PR is just a record for the issue. 