### PR TITLE
fix: handle foreign key dependencies correctly

### DIFF
--- a/cmd/mssqldef/mssqldef_test.go
+++ b/cmd/mssqldef/mssqldef_test.go
@@ -30,7 +30,7 @@ func wrapWithTransaction(ddls string) string {
 }
 
 func TestApply(t *testing.T) {
-	tests, err := testutils.ReadTests("tests.yml")
+	tests, err := testutils.ReadTests("tests*.yml")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/mssqldef/tests_fk_deps.yml
+++ b/cmd/mssqldef/tests_fk_deps.yml
@@ -1,0 +1,196 @@
+# Test cases for foreign key dependency handling in SQL Server
+
+# Issue 1: Export order with foreign key constraints
+# When exporting a database with foreign keys, the tables might be exported
+# in an order that causes dependency errors when recreating the schema
+ExportOrderForeignKey:
+  desired: |
+    CREATE TABLE [suppliers] (
+      [supplier_id] int PRIMARY KEY,
+      [name] NVARCHAR(100)
+    );
+    CREATE TABLE [items] (
+      [item_id] int PRIMARY KEY,
+      [supplier_id] int NOT NULL,
+      CONSTRAINT [items_supplier_fk] FOREIGN KEY ([supplier_id]) REFERENCES [suppliers] ([supplier_id])
+    );
+
+# Issue 2: Complex primary key change with foreign key dependencies
+# Changing primary key from single column to composite when foreign keys exist
+PrimaryKeyChangeWithForeignKey:
+  current: |
+    CREATE TABLE [items] (
+      [item_id] int,
+      [supplier_id] int,
+      [name] NVARCHAR(100),
+      CONSTRAINT [items_pkey] PRIMARY KEY ([item_id])
+    );
+    CREATE TABLE [item_prices] (
+      [price_id] int,
+      [price] DECIMAL(10,2),
+      [item_id] int,
+      CONSTRAINT [item_prices_pkey] PRIMARY KEY ([price_id]),
+      CONSTRAINT [prices_item_fk] FOREIGN KEY ([item_id]) REFERENCES [items] ([item_id])
+    );
+  desired: |
+    CREATE TABLE [items] (
+      [item_id] int NOT NULL,
+      [supplier_id] int NOT NULL,
+      [name] NVARCHAR(100),
+      PRIMARY KEY ([supplier_id], [item_id])
+    );
+    CREATE TABLE [item_prices] (
+      [price_id] int PRIMARY KEY,
+      [item_id] int,
+      [supplier_id] int,
+      [price] DECIMAL(10,2),
+      CONSTRAINT [prices_item_fk] FOREIGN KEY ([supplier_id], [item_id])
+        REFERENCES [items] ([supplier_id], [item_id])
+    );
+  output: |
+    ALTER TABLE [dbo].[items] ALTER COLUMN [supplier_id] int NOT NULL;
+    ALTER TABLE [dbo].[item_prices] DROP CONSTRAINT [prices_item_fk];
+    ALTER TABLE [dbo].[items] DROP CONSTRAINT [items_pkey];
+    ALTER TABLE [dbo].[items] ADD PRIMARY KEY NONCLUSTERED ([supplier_id], [item_id]);
+    ALTER TABLE [dbo].[item_prices] ADD [supplier_id] int;
+    ALTER TABLE [dbo].[item_prices] ADD CONSTRAINT [prices_item_fk] FOREIGN KEY ([supplier_id], [item_id]) REFERENCES [dbo].[items] ([supplier_id], [item_id]);
+
+# Issue 3: Circular foreign key dependencies
+CircularForeignKeyDependency:
+  current: |
+    CREATE TABLE [departments] (
+      [dept_id] int PRIMARY KEY,
+      [name] NVARCHAR(100)
+    );
+    CREATE TABLE [employees] (
+      [emp_id] int PRIMARY KEY,
+      [dept_id] int,
+      [name] NVARCHAR(100)
+    );
+  desired: |
+    CREATE TABLE [departments] (
+      [dept_id] int PRIMARY KEY,
+      [name] NVARCHAR(100),
+      [manager_id] int,
+      CONSTRAINT [dept_manager_fk] FOREIGN KEY ([manager_id]) REFERENCES [employees] ([emp_id])
+    );
+    CREATE TABLE [employees] (
+      [emp_id] int PRIMARY KEY,
+      [dept_id] int,
+      [name] NVARCHAR(100),
+      CONSTRAINT [emp_dept_fk] FOREIGN KEY ([dept_id]) REFERENCES [departments] ([dept_id])
+    );
+  output: |
+    ALTER TABLE [dbo].[departments] ADD [manager_id] int;
+    ALTER TABLE [dbo].[departments] ADD CONSTRAINT [dept_manager_fk] FOREIGN KEY ([manager_id]) REFERENCES [dbo].[employees] ([emp_id]);
+    ALTER TABLE [dbo].[employees] ADD CONSTRAINT [emp_dept_fk] FOREIGN KEY ([dept_id]) REFERENCES [dbo].[departments] ([dept_id]);
+
+# Issue 4: Add constraint after table creation
+AddConstraintAfterCreation:
+  current: |
+    CREATE TABLE [orders] (
+      [order_id] int PRIMARY KEY,
+      [customer_id] int,
+      [order_date] DATE
+    );
+    CREATE TABLE [customers] (
+      [customer_id] int PRIMARY KEY,
+      [name] NVARCHAR(100)
+    );
+  desired: |
+    CREATE TABLE [customers] (
+      [customer_id] int PRIMARY KEY,
+      [name] NVARCHAR(100)
+    );
+    CREATE TABLE [orders] (
+      [order_id] int PRIMARY KEY,
+      [customer_id] int,
+      [order_date] DATE,
+      CONSTRAINT [order_customer_fk] FOREIGN KEY ([customer_id]) REFERENCES [customers] ([customer_id])
+    );
+  output: |
+    ALTER TABLE [dbo].[orders] ADD CONSTRAINT [order_customer_fk] FOREIGN KEY ([customer_id]) REFERENCES [dbo].[customers] ([customer_id]);
+
+# Issue 5: Multiple foreign keys to same table being modified
+MultipleForeignKeysToModifiedTable:
+  current: |
+    CREATE TABLE [users] (
+      [user_id] int,
+      [username] NVARCHAR(50),
+      CONSTRAINT [users_pkey] PRIMARY KEY ([user_id])
+    );
+    CREATE TABLE [posts] (
+      [post_id] int,
+      [author_id] int,
+      [reviewer_id] int,
+      CONSTRAINT [posts_pkey] PRIMARY KEY ([post_id]),
+      CONSTRAINT [posts_author_fk] FOREIGN KEY ([author_id]) REFERENCES [users] ([user_id]),
+      CONSTRAINT [posts_reviewer_fk] FOREIGN KEY ([reviewer_id]) REFERENCES [users] ([user_id])
+    );
+  desired: |
+    CREATE TABLE [users] (
+      [user_id] int NOT NULL,
+      [username] NVARCHAR(50),
+      [tenant_id] int NOT NULL,
+      PRIMARY KEY ([tenant_id], [user_id])
+    );
+    CREATE TABLE [posts] (
+      [post_id] int PRIMARY KEY,
+      [author_id] int,
+      [author_tenant_id] int,
+      [reviewer_id] int,
+      [reviewer_tenant_id] int,
+      CONSTRAINT [posts_author_fk] FOREIGN KEY ([author_tenant_id], [author_id])
+        REFERENCES [users] ([tenant_id], [user_id]),
+      CONSTRAINT [posts_reviewer_fk] FOREIGN KEY ([reviewer_tenant_id], [reviewer_id])
+        REFERENCES [users] ([tenant_id], [user_id])
+    );
+  output: |
+    ALTER TABLE [dbo].[users] ADD [tenant_id] int NOT NULL;
+    ALTER TABLE [dbo].[posts] DROP CONSTRAINT [posts_author_fk];
+    ALTER TABLE [dbo].[posts] DROP CONSTRAINT [posts_reviewer_fk];
+    ALTER TABLE [dbo].[users] DROP CONSTRAINT [users_pkey];
+    ALTER TABLE [dbo].[users] ADD PRIMARY KEY NONCLUSTERED ([tenant_id], [user_id]);
+    ALTER TABLE [dbo].[posts] ADD [author_tenant_id] int;
+    ALTER TABLE [dbo].[posts] ADD [reviewer_tenant_id] int;
+    ALTER TABLE [dbo].[posts] ADD CONSTRAINT [posts_author_fk] FOREIGN KEY ([author_tenant_id], [author_id]) REFERENCES [dbo].[users] ([tenant_id], [user_id]);
+    ALTER TABLE [dbo].[posts] ADD CONSTRAINT [posts_reviewer_fk] FOREIGN KEY ([reviewer_tenant_id], [reviewer_id]) REFERENCES [dbo].[users] ([tenant_id], [user_id]);
+
+# Issue 6: CASCADE options preservation
+CascadeOptionsPreservation:
+  current: |
+    CREATE TABLE [categories] (
+      [category_id] int,
+      [name] NVARCHAR(100),
+      CONSTRAINT [categories_pkey] PRIMARY KEY ([category_id])
+    );
+    CREATE TABLE [products] (
+      [product_id] int,
+      [category_id] int,
+      [name] NVARCHAR(100),
+      CONSTRAINT [products_pkey] PRIMARY KEY ([product_id]),
+      CONSTRAINT [products_category_fk] FOREIGN KEY ([category_id])
+        REFERENCES [categories] ([category_id]) ON DELETE CASCADE ON UPDATE CASCADE
+    );
+  desired: |
+    CREATE TABLE [categories] (
+      [category_id] int NOT NULL,
+      [tenant_id] int NOT NULL,
+      [name] NVARCHAR(100),
+      PRIMARY KEY ([tenant_id], [category_id])
+    );
+    CREATE TABLE [products] (
+      [product_id] int PRIMARY KEY,
+      [category_id] int,
+      [tenant_id] int,
+      [name] NVARCHAR(100),
+      CONSTRAINT [products_category_fk] FOREIGN KEY ([tenant_id], [category_id])
+        REFERENCES [categories] ([tenant_id], [category_id]) ON DELETE CASCADE ON UPDATE CASCADE
+    );
+  output: |
+    ALTER TABLE [dbo].[categories] ADD [tenant_id] int NOT NULL;
+    ALTER TABLE [dbo].[products] DROP CONSTRAINT [products_category_fk];
+    ALTER TABLE [dbo].[categories] DROP CONSTRAINT [categories_pkey];
+    ALTER TABLE [dbo].[categories] ADD PRIMARY KEY NONCLUSTERED ([tenant_id], [category_id]);
+    ALTER TABLE [dbo].[products] ADD [tenant_id] int;
+    ALTER TABLE [dbo].[products] ADD CONSTRAINT [products_category_fk] FOREIGN KEY ([tenant_id], [category_id]) REFERENCES [dbo].[categories] ([tenant_id], [category_id]) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/cmd/mysqldef/tests_fk_deps.yml
+++ b/cmd/mysqldef/tests_fk_deps.yml
@@ -1,0 +1,163 @@
+# Test cases to reproduce issues mentioned in the Qiita article
+# https://qiita.com/abe_masanori/items/7fd2a470e7eba2f255a4
+
+# Issue 1: Export order with foreign key constraints
+# When exporting a database with foreign keys, the tables might be exported
+# in an order that causes dependency errors when recreating the schema
+ExportOrderForeignKey:
+  desired: |
+    CREATE TABLE `suppliers` (
+      `supplier_id` int PRIMARY KEY,
+      `name` VARCHAR(100)
+    );
+    CREATE TABLE `items` (
+      `item_id` int PRIMARY KEY,
+      `supplier_id` int NOT NULL,
+      CONSTRAINT `items_supplier_fk` FOREIGN KEY (`supplier_id`) REFERENCES `suppliers` (`supplier_id`)
+    );
+
+# Issue 2: Complex primary key change with foreign key dependencies
+# Changing primary key from single column to composite when foreign keys exist
+# This test demonstrates the limitation when trying to change a primary key
+# that is referenced by foreign keys
+PrimaryKeyChangeWithForeignKey:
+  current: |
+    CREATE TABLE `items` (
+      `item_id` int PRIMARY KEY,
+      `supplier_id` int,
+      `name` VARCHAR(100)
+    );
+    CREATE TABLE `item_prices` (
+      `price_id` int PRIMARY KEY,
+      `item_id` int,
+      `price` DECIMAL(10,2),
+      CONSTRAINT `prices_item_fk` FOREIGN KEY (`item_id`) REFERENCES `items` (`item_id`)
+    );
+  desired: |
+    CREATE TABLE `items` (
+      `item_id` int NOT NULL,
+      `supplier_id` int NOT NULL,
+      `name` VARCHAR(100),
+      PRIMARY KEY (`supplier_id`, `item_id`)
+    );
+    CREATE TABLE `item_prices` (
+      `price_id` int PRIMARY KEY,
+      `item_id` int,
+      `supplier_id` int,
+      `price` DECIMAL(10,2),
+      CONSTRAINT `prices_item_fk` FOREIGN KEY (`supplier_id`, `item_id`)
+        REFERENCES `items` (`supplier_id`, `item_id`)
+    );
+  output: |
+    ALTER TABLE `items` CHANGE COLUMN `supplier_id` `supplier_id` int NOT NULL;
+    ALTER TABLE `item_prices` DROP FOREIGN KEY `prices_item_fk`;
+    ALTER TABLE `item_prices` DROP INDEX `prices_item_fk`;
+    ALTER TABLE `items` DROP PRIMARY KEY;
+    ALTER TABLE `items` ADD PRIMARY KEY (`supplier_id`, `item_id`);
+    ALTER TABLE `item_prices` ADD COLUMN `supplier_id` int AFTER `item_id`;
+    ALTER TABLE `item_prices` ADD CONSTRAINT `prices_item_fk` FOREIGN KEY (`supplier_id`, `item_id`) REFERENCES `items` (`supplier_id`, `item_id`);
+
+# Issue 3: Circular foreign key dependencies
+CircularForeignKeyDependency:
+  current: |
+    CREATE TABLE `departments` (
+      `dept_id` int PRIMARY KEY,
+      `name` VARCHAR(100)
+    );
+    CREATE TABLE `employees` (
+      `emp_id` int PRIMARY KEY,
+      `dept_id` int,
+      `name` VARCHAR(100)
+    );
+  desired: |
+    CREATE TABLE `departments` (
+      `dept_id` int PRIMARY KEY,
+      `name` VARCHAR(100),
+      `manager_id` int
+    );
+    CREATE TABLE `employees` (
+      `emp_id` int PRIMARY KEY,
+      `dept_id` int,
+      `name` VARCHAR(100),
+      CONSTRAINT `emp_dept_fk` FOREIGN KEY (`dept_id`) REFERENCES `departments` (`dept_id`)
+    );
+    ALTER TABLE `departments` ADD CONSTRAINT `dept_manager_fk`
+      FOREIGN KEY (`manager_id`) REFERENCES `employees` (`emp_id`);
+  output: |
+    ALTER TABLE `departments` ADD COLUMN `manager_id` int AFTER `name`;
+    ALTER TABLE `employees` ADD CONSTRAINT `emp_dept_fk` FOREIGN KEY (`dept_id`) REFERENCES `departments` (`dept_id`);
+    ALTER TABLE `departments` ADD CONSTRAINT `dept_manager_fk`
+      FOREIGN KEY (`manager_id`) REFERENCES `employees` (`emp_id`);
+
+# Issue 4: Add constraint after table creation (mentioned as limited support)
+AddConstraintAfterCreation:
+  current: |
+    CREATE TABLE `orders` (
+      `order_id` int PRIMARY KEY,
+      `customer_id` int,
+      `order_date` DATE
+    );
+    CREATE TABLE `customers` (
+      `customer_id` int PRIMARY KEY,
+      `name` VARCHAR(100)
+    );
+  desired: |
+    CREATE TABLE `orders` (
+      `order_id` int PRIMARY KEY,
+      `customer_id` int,
+      `order_date` DATE
+    );
+    CREATE TABLE `customers` (
+      `customer_id` int PRIMARY KEY,
+      `name` VARCHAR(100)
+    );
+    ALTER TABLE `orders` ADD CONSTRAINT `order_customer_fk`
+      FOREIGN KEY (`customer_id`) REFERENCES `customers` (`customer_id`);
+  output: |
+    ALTER TABLE `orders` ADD CONSTRAINT `order_customer_fk`
+      FOREIGN KEY (`customer_id`) REFERENCES `customers` (`customer_id`);
+
+# Issue 5: Multiple foreign keys to same table being modified
+MultipleForeignKeysToModifiedTable:
+  current: |
+    CREATE TABLE `users` (
+      `user_id` int PRIMARY KEY,
+      `username` VARCHAR(50)
+    );
+    CREATE TABLE `posts` (
+      `post_id` int PRIMARY KEY,
+      `author_id` int,
+      `reviewer_id` int,
+      CONSTRAINT `posts_author_fk` FOREIGN KEY (`author_id`) REFERENCES `users` (`user_id`),
+      CONSTRAINT `posts_reviewer_fk` FOREIGN KEY (`reviewer_id`) REFERENCES `users` (`user_id`)
+    );
+  desired: |
+    CREATE TABLE `users` (
+      `user_id` int NOT NULL,
+      `username` VARCHAR(50),
+      `tenant_id` int NOT NULL,
+      PRIMARY KEY (`tenant_id`, `user_id`)
+    );
+    CREATE TABLE `posts` (
+      `post_id` int PRIMARY KEY,
+      `author_id` int,
+      `author_tenant_id` int,
+      `reviewer_id` int,
+      `reviewer_tenant_id` int,
+      CONSTRAINT `posts_author_fk` FOREIGN KEY (`author_tenant_id`, `author_id`)
+        REFERENCES `users` (`tenant_id`, `user_id`),
+      CONSTRAINT `posts_reviewer_fk` FOREIGN KEY (`reviewer_tenant_id`, `reviewer_id`)
+        REFERENCES `users` (`tenant_id`, `user_id`)
+    );
+  output: |
+    ALTER TABLE `users` ADD COLUMN `tenant_id` int NOT NULL AFTER `username`;
+    ALTER TABLE `posts` DROP FOREIGN KEY `posts_author_fk`;
+    ALTER TABLE `posts` DROP INDEX `posts_author_fk`;
+    ALTER TABLE `posts` DROP FOREIGN KEY `posts_reviewer_fk`;
+    ALTER TABLE `posts` DROP INDEX `posts_reviewer_fk`;
+    ALTER TABLE `users` DROP PRIMARY KEY;
+    ALTER TABLE `users` ADD PRIMARY KEY (`tenant_id`, `user_id`);
+    ALTER TABLE `posts` ADD COLUMN `author_tenant_id` int AFTER `author_id`;
+    ALTER TABLE `posts` ADD COLUMN `reviewer_tenant_id` int AFTER `reviewer_id`;
+    ALTER TABLE `posts` ADD CONSTRAINT `posts_author_fk` FOREIGN KEY (`author_tenant_id`, `author_id`) REFERENCES `users` (`tenant_id`, `user_id`);
+    ALTER TABLE `posts` ADD CONSTRAINT `posts_reviewer_fk` FOREIGN KEY (`reviewer_tenant_id`, `reviewer_id`) REFERENCES `users` (`tenant_id`, `user_id`);

--- a/cmd/psqldef/tests.yml
+++ b/cmd/psqldef/tests.yml
@@ -310,11 +310,11 @@ ForeignKeyConstraintsAreEmittedLast:
       bar_id bigint PRIMARY KEY
     );
   output: |
+    ALTER TABLE "public"."bars" ADD COLUMN "bar_id" bigint NOT NULL;
+    ALTER TABLE "public"."bars" ADD PRIMARY KEY ("bar_id");
     ALTER TABLE "public"."foos" ADD COLUMN "foo_id" bigint NOT NULL;
     ALTER TABLE "public"."foos" ADD COLUMN "bar_id" bigint NOT NULL;
     ALTER TABLE "public"."foos" ADD PRIMARY KEY ("foo_id");
-    ALTER TABLE "public"."bars" ADD COLUMN "bar_id" bigint NOT NULL;
-    ALTER TABLE "public"."bars" ADD PRIMARY KEY ("bar_id");
     ALTER TABLE "public"."foos" ADD CONSTRAINT "foos_bar_id_fkey" FOREIGN KEY ("bar_id") REFERENCES "public"."bars" ("bar_id");
     ALTER TABLE "public"."bars" DROP COLUMN "dummy_column";
     ALTER TABLE "public"."foos" DROP COLUMN "dummy_column";

--- a/cmd/psqldef/tests_fk_deps.yml
+++ b/cmd/psqldef/tests_fk_deps.yml
@@ -1,0 +1,190 @@
+# Test cases for foreign key dependency handling in PostgreSQL
+
+# Issue 1: Export order with foreign key constraints
+# When exporting a database with foreign keys, the tables might be exported
+# in an order that causes dependency errors when recreating the schema
+ExportOrderForeignKey:
+  desired: |
+    CREATE TABLE suppliers (
+      supplier_id int PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE TABLE items (
+      item_id int PRIMARY KEY,
+      supplier_id int NOT NULL,
+      CONSTRAINT items_supplier_fk FOREIGN KEY (supplier_id) REFERENCES suppliers (supplier_id)
+    );
+
+# Issue 2: Complex primary key change with foreign key dependencies
+# Changing primary key from single column to composite when foreign keys exist
+PrimaryKeyChangeWithForeignKey:
+  current: |
+    CREATE TABLE items (
+      item_id int PRIMARY KEY,
+      supplier_id int,
+      name VARCHAR(100)
+    );
+    CREATE TABLE item_prices (
+      price_id int PRIMARY KEY,
+      item_id int,
+      price DECIMAL(10,2),
+      CONSTRAINT prices_item_fk FOREIGN KEY (item_id) REFERENCES items (item_id)
+    );
+  desired: |
+    CREATE TABLE items (
+      item_id int NOT NULL,
+      supplier_id int NOT NULL,
+      name VARCHAR(100),
+      PRIMARY KEY (supplier_id, item_id)
+    );
+    CREATE TABLE item_prices (
+      price_id int PRIMARY KEY,
+      item_id int,
+      supplier_id int,
+      price DECIMAL(10,2),
+      CONSTRAINT prices_item_fk FOREIGN KEY (supplier_id, item_id)
+        REFERENCES items (supplier_id, item_id)
+    );
+  output: |
+    ALTER TABLE "public"."items" ALTER COLUMN "supplier_id" SET NOT NULL;
+    ALTER TABLE "public"."item_prices" DROP CONSTRAINT "prices_item_fk";
+    ALTER TABLE "public"."items" DROP CONSTRAINT "items_pkey";
+    ALTER TABLE "public"."items" ADD PRIMARY KEY ("supplier_id", "item_id");
+    ALTER TABLE "public"."item_prices" ADD COLUMN "supplier_id" integer;
+    ALTER TABLE "public"."item_prices" ADD CONSTRAINT "prices_item_fk" FOREIGN KEY ("supplier_id", "item_id") REFERENCES "public"."items" ("supplier_id", "item_id");
+
+# Issue 3: Circular foreign key dependencies
+CircularForeignKeyDependency:
+  current: |
+    CREATE TABLE departments (
+      dept_id int PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE TABLE employees (
+      emp_id int PRIMARY KEY,
+      dept_id int,
+      name VARCHAR(100)
+    );
+  desired: |
+    CREATE TABLE departments (
+      dept_id int PRIMARY KEY,
+      name VARCHAR(100),
+      manager_id int,
+      CONSTRAINT dept_manager_fk FOREIGN KEY (manager_id) REFERENCES employees (emp_id)
+    );
+    CREATE TABLE employees (
+      emp_id int PRIMARY KEY,
+      dept_id int,
+      name VARCHAR(100),
+      CONSTRAINT emp_dept_fk FOREIGN KEY (dept_id) REFERENCES departments (dept_id)
+    );
+  output: |
+    ALTER TABLE "public"."departments" ADD COLUMN "manager_id" integer;
+    ALTER TABLE "public"."departments" ADD CONSTRAINT "dept_manager_fk" FOREIGN KEY ("manager_id") REFERENCES "public"."employees" ("emp_id");
+    ALTER TABLE "public"."employees" ADD CONSTRAINT "emp_dept_fk" FOREIGN KEY ("dept_id") REFERENCES "public"."departments" ("dept_id");
+
+# Issue 4: Add constraint after table creation
+AddConstraintAfterCreation:
+  current: |
+    CREATE TABLE orders (
+      order_id int PRIMARY KEY,
+      customer_id int,
+      order_date DATE
+    );
+    CREATE TABLE customers (
+      customer_id int PRIMARY KEY,
+      name VARCHAR(100)
+    );
+  desired: |
+    CREATE TABLE customers (
+      customer_id int PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE TABLE orders (
+      order_id int PRIMARY KEY,
+      customer_id int,
+      order_date DATE,
+      CONSTRAINT order_customer_fk FOREIGN KEY (customer_id) REFERENCES customers (customer_id)
+    );
+  output: |
+    ALTER TABLE "public"."orders" ADD CONSTRAINT "order_customer_fk" FOREIGN KEY ("customer_id") REFERENCES "public"."customers" ("customer_id");
+
+# Issue 5: Multiple foreign keys to same table being modified
+MultipleForeignKeysToModifiedTable:
+  current: |
+    CREATE TABLE users (
+      user_id int PRIMARY KEY,
+      username VARCHAR(50)
+    );
+    CREATE TABLE posts (
+      post_id int PRIMARY KEY,
+      author_id int,
+      reviewer_id int,
+      CONSTRAINT posts_author_fk FOREIGN KEY (author_id) REFERENCES users (user_id),
+      CONSTRAINT posts_reviewer_fk FOREIGN KEY (reviewer_id) REFERENCES users (user_id)
+    );
+  desired: |
+    CREATE TABLE users (
+      user_id int NOT NULL,
+      username VARCHAR(50),
+      tenant_id int NOT NULL,
+      PRIMARY KEY (tenant_id, user_id)
+    );
+    CREATE TABLE posts (
+      post_id int PRIMARY KEY,
+      author_id int,
+      author_tenant_id int,
+      reviewer_id int,
+      reviewer_tenant_id int,
+      CONSTRAINT posts_author_fk FOREIGN KEY (author_tenant_id, author_id)
+        REFERENCES users (tenant_id, user_id),
+      CONSTRAINT posts_reviewer_fk FOREIGN KEY (reviewer_tenant_id, reviewer_id)
+        REFERENCES users (tenant_id, user_id)
+    );
+  output: |
+    ALTER TABLE "public"."users" ADD COLUMN "tenant_id" integer NOT NULL;
+    ALTER TABLE "public"."posts" DROP CONSTRAINT "posts_author_fk";
+    ALTER TABLE "public"."posts" DROP CONSTRAINT "posts_reviewer_fk";
+    ALTER TABLE "public"."users" DROP CONSTRAINT "users_pkey";
+    ALTER TABLE "public"."users" ADD PRIMARY KEY ("tenant_id", "user_id");
+    ALTER TABLE "public"."posts" ADD COLUMN "author_tenant_id" integer;
+    ALTER TABLE "public"."posts" ADD COLUMN "reviewer_tenant_id" integer;
+    ALTER TABLE "public"."posts" ADD CONSTRAINT "posts_author_fk" FOREIGN KEY ("author_tenant_id", "author_id") REFERENCES "public"."users" ("tenant_id", "user_id");
+    ALTER TABLE "public"."posts" ADD CONSTRAINT "posts_reviewer_fk" FOREIGN KEY ("reviewer_tenant_id", "reviewer_id") REFERENCES "public"."users" ("tenant_id", "user_id");
+
+# Issue 6: CASCADE options preservation
+CascadeOptionsPreservation:
+  current: |
+    CREATE TABLE categories (
+      category_id int PRIMARY KEY,
+      name VARCHAR(100)
+    );
+    CREATE TABLE products (
+      product_id int PRIMARY KEY,
+      category_id int,
+      name VARCHAR(100),
+      CONSTRAINT products_category_fk FOREIGN KEY (category_id)
+        REFERENCES categories (category_id) ON DELETE CASCADE ON UPDATE CASCADE
+    );
+  desired: |
+    CREATE TABLE categories (
+      category_id int NOT NULL,
+      tenant_id int NOT NULL,
+      name VARCHAR(100),
+      PRIMARY KEY (tenant_id, category_id)
+    );
+    CREATE TABLE products (
+      product_id int PRIMARY KEY,
+      category_id int,
+      tenant_id int,
+      name VARCHAR(100),
+      CONSTRAINT products_category_fk FOREIGN KEY (tenant_id, category_id)
+        REFERENCES categories (tenant_id, category_id) ON DELETE CASCADE ON UPDATE CASCADE
+    );
+  output: |
+    ALTER TABLE "public"."categories" ADD COLUMN "tenant_id" integer NOT NULL;
+    ALTER TABLE "public"."products" DROP CONSTRAINT "products_category_fk";
+    ALTER TABLE "public"."categories" DROP CONSTRAINT "categories_pkey";
+    ALTER TABLE "public"."categories" ADD PRIMARY KEY ("tenant_id", "category_id");
+    ALTER TABLE "public"."products" ADD COLUMN "tenant_id" integer;
+    ALTER TABLE "public"."products" ADD CONSTRAINT "products_category_fk" FOREIGN KEY ("tenant_id", "category_id") REFERENCES "public"."categories" ("tenant_id", "category_id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/cmd/sqlite3def/sqlite3def_test.go
+++ b/cmd/sqlite3def/sqlite3def_test.go
@@ -31,7 +31,7 @@ func wrapWithTransaction(ddls string) string {
 func TestApply(t *testing.T) {
 	defer testutils.MustExecute("rm", "-f", "sqlite3def_test") // after-test cleanup
 
-	tests, err := testutils.ReadTests("tests.yml")
+	tests, err := testutils.ReadTests("tests*.yml")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/testutils/testutils.go
+++ b/cmd/testutils/testutils.go
@@ -206,6 +206,8 @@ func splitDDLs(mode schema.GeneratorMode, sqlParser database.Parser, str string,
 		return nil, err
 	}
 
+	statements = schema.SortTablesByDependencies(statements)
+
 	var ddls []string
 	for _, statement := range statements {
 		ddls = append(ddls, statement.Statement())


### PR DESCRIPTION
Fixed issues reported in the article:

https://qiita.com/abe_masanori/items/7fd2a470e7eba2f255a4

Key improvements demonstrated by the new tests:

1. Table creation order (ExportOrderForeignKey)
   - Tables are now created in dependency order, ensuring referenced tables exist before foreign keys are added
2. Primary key modifications with foreign key dependencies (PrimaryKeyChangeWithForeignKey)
   - Properly handles changing primary keys from single to composite columns when foreign keys reference them
   - Automatically drops and recreates affected foreign key constraints in the correct order
3. Circular foreign key dependencies (CircularForeignKeyDependency)
   - Supports schemas where tables have mutual foreign key references (e.g., departments ↔ employees)
4. Dynamic constraint addition (AddConstraintAfterCreation)
   - Can add foreign key constraints to existing tables without issues
5. Multiple foreign keys to modified tables (MultipleForeignKeysToModifiedTable)
   - Correctly handles multiple foreign keys pointing to the same table when that table's primary key structure changes
   - Preserves all foreign key relationships during complex migrations
