### PR TITLE
Fix partial index WHERE IN/NOT IN idempotency for unsorted values

### DIFF
--- a/cmd/psqldef/tests_indices.yml
+++ b/cmd/psqldef/tests_indices.yml
@@ -507,6 +507,20 @@ PartialIndexWithWhereNotIn:
     CREATE INDEX idx_non_cancelled ON orders (id)
     WHERE status NOT IN ('cancelled', 'deleted');
 
+PartialIndexWithWhereInUnsorted:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE orders (id integer, status text);
+    CREATE UNIQUE INDEX uk_orders_status ON orders (id)
+    WHERE status IN ('pending', 'active');
+
+PartialIndexWithWhereNotInUnsorted:
+  legacy_ignore_quotes: false
+  desired: |
+    CREATE TABLE orders (id integer, status text);
+    CREATE INDEX idx_non_cancelled ON orders (id)
+    WHERE status NOT IN ('deleted', 'cancelled');
+
 IndexWithNullsNotDistinct:
   legacy_ignore_quotes: false
   min_version: "15"

--- a/cmd/sqlite3def/tests.yml
+++ b/cmd/sqlite3def/tests.yml
@@ -425,6 +425,16 @@ PartialIndexWithWhereNotIn:
     CREATE TABLE orders (id integer, status text);
     CREATE INDEX idx_non_cancelled ON orders (id)
     WHERE status NOT IN ('cancelled', 'deleted');
+PartialIndexWithWhereInUnsorted:
+  desired: |
+    CREATE TABLE orders (id integer, status text);
+    CREATE INDEX idx_active ON orders (id)
+    WHERE status IN ('pending', 'active');
+PartialIndexWithWhereNotInUnsorted:
+  desired: |
+    CREATE TABLE orders (id integer, status text);
+    CREATE INDEX idx_non_cancelled ON orders (id)
+    WHERE status NOT IN ('deleted', 'cancelled');
 NumericDecimalWithoutPrecision:
   current: |
     CREATE TABLE test (

--- a/schema/normalize.go
+++ b/schema/normalize.go
@@ -767,13 +767,13 @@ func normalizeExpr(expr parser.Expr, mode GeneratorMode) parser.Expr {
 			}
 		}
 
-		// For existing ANY/ALL expressions, normalize the array elements.
+		// For existing ANY/ALL expressions, normalize and sort the array elements.
 		if anyFlag || allFlag {
 			if arrayConst, ok := right.(*parser.ArrayConstructor); ok {
 				normalizedElements := util.TransformSlice(arrayConst.Elements, func(elem parser.Expr) parser.Expr {
 					return normalizeExpr(elem, mode)
 				})
-				right = &parser.ArrayConstructor{Elements: normalizedElements}
+				right = &parser.ArrayConstructor{Elements: sortAndDeduplicateValues(normalizedElements)}
 			}
 		}
 


### PR DESCRIPTION
## Summary

`psqldef` generates unnecessary `DROP INDEX` + `CREATE INDEX` statements for partial indexes when `WHERE column IN (...)` values are not in alphabetical order, even when the schema is already up to date.

This is a follow-up fix for #1179, which added IN-to-ANY normalization but missed sorting in one code path.

## Root Cause

`normalizeExpr()` has two code paths that produce `= ANY(ARRAY[...])`:

1. **IN path** (for desired schema): converts `IN (...)` to `= ANY(ARRAY[...])` with `sortAndDeduplicateValues()`
2. **ANY/ALL path** (for exported schema): normalizes existing `= ANY(ARRAY[...])` elements but does **not** sort them

When IN values are not in alphabetical order (e.g., `IN ('pending', 'active')`), the desired schema normalizes to `= ANY(ARRAY['active', 'pending'])` (sorted), while the exported schema stays as `= ANY(ARRAY['pending', 'active'])` (unsorted). This mismatch causes `areSameWhereClause()` to return false.

The test cases added in #1179 happened to use values already in alphabetical order (`('active', 'pending')`), so this bug was not caught.

## Fix

Added `sortAndDeduplicateValues()` to the ANY/ALL array normalization path in `normalizeExpr()`, matching the IN path's behavior.

## Changes

- `schema/normalize.go`: Added sorting to the ANY/ALL array element normalization
- `cmd/psqldef/tests_indices.yml`: Added `PartialIndexWithWhereInUnsorted` and `PartialIndexWithWhereNotInUnsorted` test cases
- `cmd/sqlite3def/tests.yml`: Added `PartialIndexWithWhereInUnsorted` and `PartialIndexWithWhereNotInUnsorted` test cases

## Testing

- `PSQLDEF_PARSER=generic go test ./cmd/psqldef` — all tests pass
- `go test ./cmd/sqlite3def` — all tests pass
- `make build && make format && make lint` — all pass